### PR TITLE
Introducing LoanConfig (per account)

### DIFF
--- a/daml-model/daml/Model/LoanConfig.daml
+++ b/daml-model/daml/Model/LoanConfig.daml
@@ -6,42 +6,60 @@
 module Model.LoanConfig where
 
 import Model.Balance
+import DA.Optional
 
 type Amount = Decimal
 type IBAN = Text
 
 -- Loan configuration on account (e.g. IBAN) level
+-- The idea is to provide the {accountHolder} with individual loans up {maxLoanPerTransaction},
+-- as long as {maxLoanThreshold} has not been reached (as tracked by {activeLoan}).
 template LoanConfig
     with
         provider: Party
+        -- ^ Account provider
         accountHolder: Party
+        -- ^ Account holder
         account: IBAN
-        maxLoan: Amount
+        -- ^ Account number
+        maxLoanPerTransaction: Amount
+        -- ^ Defines the limit of a single loan
+        maxLoanThreshold: Amount
+        -- ^ Defines the limit of all loans given to this account
         activeLoan: Amount
-        paybackThreshold: Amount
-        paybackAccount: IBAN
+        -- ^ Sum of currently active loans
+        paybackThreshold: Optional Amount
+        -- ^ Defines at which balance amount the loan will be paid back
 
     where
-        signatory provider, accountHolder
+        -- TODO: multisig (propose/accept)
+        -- signatory provider, accountHolder
+        signatory provider
+        observer accountHolder
         key (BalanceKey with iban = account, provider = provider) : BalanceKey
         maintainer key.provider
 
-        ensure activeLoan <= maxLoan
+        ensure activeLoan >= 0.0
+            && activeLoan <= maxLoanThreshold
+            && maxLoanPerTransaction >= 0.0
+            && maxLoanPerTransaction <= maxLoanThreshold
         
-        let remainingLoanAmount = maxLoan - activeLoan
+        let currentLoanAmount = min maxLoanPerTransaction (maxLoanThreshold - activeLoan)
             balanceKey = BalanceKey accountHolder account
 
         choice CreateLoan: (ContractId LoanConfig, ContractId Balance)
             with
-                loanAmount: Amount
+                loanAmount: Optional Amount
+                -- ^ None implies to grant the current max loan amount
             controller provider
                 do
-                    assertMsg ("Maximum available loan is: " <> show remainingLoanAmount) $ remainingLoanAmount >= loanAmount
+                    let amount = fromOptional currentLoanAmount loanAmount
+                    assertMsg ("Maximum available loan is: " <> show currentLoanAmount) $ currentLoanAmount >= amount
                     balance <- lookupByKey @Balance balanceKey
                     case balance of
                         Some balanceCid -> do
-                            balanceNewCid <- exercise balanceCid Increase with increment = loanAmount
-                            loanConfigCid <- create this with activeLoan = activeLoan + loanAmount
+                            balanceNewCid <- exercise balanceCid Increase with increment = amount
+                            loanConfigCid <- create this with activeLoan = activeLoan + amount
                             pure (loanConfigCid, balanceNewCid)
-                        None -> error $ "No Balance found for BalanceKey: " <> show balanceKey                  
+                        None -> error $ "No Balance found for BalanceKey: " <> show balanceKey
     

--- a/daml-model/daml/Model/LoanConfig.daml
+++ b/daml-model/daml/Model/LoanConfig.daml
@@ -11,9 +11,12 @@ import DA.Optional
 type Amount = Decimal
 type IBAN = Text
 
--- Loan configuration on account (e.g. IBAN) level
--- The idea is to provide the {accountHolder} with individual loans up {maxLoanPerTransaction},
--- as long as {maxLoanThreshold} has not been reached (as tracked by {activeLoan}).
+{-
+Loan configuration on account (e.g. Provider/IBAN) level
+The idea is to provide the {accountHolder} with individual loans 
+up until {balanceLoanThreshold} is reached and as long as {maxLoanThreshold} 
+has not been reached (as tracked by {activeLoan}).
+-}
 template LoanConfig
     with
         provider: Party
@@ -22,14 +25,14 @@ template LoanConfig
         -- ^ Account holder
         account: IBAN
         -- ^ Account number
-        maxLoanPerTransaction: Amount
-        -- ^ Defines the limit of a single loan
+        balanceLoanThreshold: Amount
+        -- ^ Defines the balance up until which loans will be provided
         maxLoanThreshold: Amount
         -- ^ Defines the limit of all loans given to this account
         activeLoan: Amount
         -- ^ Sum of currently active loans
-        paybackThreshold: Optional Amount
-        -- ^ Defines at which balance amount the loan will be paid back
+        balancePaybackThreshold: Amount
+        -- ^ Defines above which balance amount the loan will be paid back
 
     where
         signatory provider
@@ -39,25 +42,64 @@ template LoanConfig
 
         ensure activeLoan >= 0.0
             && activeLoan <= maxLoanThreshold
-            && maxLoanPerTransaction >= 0.0
-            && maxLoanPerTransaction <= maxLoanThreshold
+            && balanceLoanThreshold >= 0.0
+            && balanceLoanThreshold <= maxLoanThreshold
+            && balancePaybackThreshold > maxLoanThreshold 
         
-        let currentLoanAmount = min maxLoanPerTransaction (maxLoanThreshold - activeLoan)
+        let currentMaxLoanAmount balance = min (max (balanceLoanThreshold - balance) 0.0) (maxLoanThreshold - activeLoan)
+            currentMaxPaybackAmount balance = min (max (balance - balancePaybackThreshold) 0.0) activeLoan
             balanceKey = BalanceKey accountHolder account
+            getBalance = do
+                visible <- visibleByKey @Balance balanceKey
+                if visible then error $ "No Balance found for BalanceKey: " <> show balanceKey
+                else do
+                    (balanceCid, balance) <- fetchByKey @Balance balanceKey
+                    return (balanceCid, balance)
 
+        {-
+        Increases balance of associated account and adds new loan to active loans.
+
+        For example: 
+        - Account A with Balance = 50.0 
+        - LoanConfig with balanceLoanThreshold = 200.0, maxLoanThreshold = 1000.0, activeLoan = 0.0
+        > In this case, account A would be funded with 150.0 (resulting in a total balance of 200.0) 
+        > in order to reach the targeted balanceLoanThreshold. Consequently, the new activeLoan = 150.0.
+        > In contrast, if prior to the loan giving activeLoan = 1000.0, no loan would be given as 
+        > the maxLoanThreshold has already been reached.
+        -}
         choice CreateLoan: (ContractId LoanConfig, ContractId Balance)
             with
                 loanAmount: Optional Amount
                 -- ^ None implies to grant the current max loan amount
             controller provider
                 do
-                    let amount = fromOptional currentLoanAmount loanAmount
-                    assertMsg ("Maximum available loan is: " <> show currentLoanAmount) $ currentLoanAmount >= amount
-                    balance <- lookupByKey @Balance balanceKey
-                    case balance of
-                        Some balanceCid -> do
-                            balanceNewCid <- exercise balanceCid Increase with increment = amount
-                            loanConfigCid <- create this with activeLoan = activeLoan + amount
-                            pure (loanConfigCid, balanceNewCid)
-                        None -> error $ "No Balance found for BalanceKey: " <> show balanceKey
-                        
+                    (balanceCid, balance) <- getBalance
+                    let maxAmount = currentMaxLoanAmount balance.amount
+                    let amount = fromOptional maxAmount loanAmount
+                    assertMsg ("Maximum available loan is: " <> show maxAmount) $ maxAmount >= amount
+                    balanceNewCid <- exercise balanceCid Increase with increment = amount
+                    loanConfigCid <- create this with activeLoan = activeLoan + amount
+                    pure (loanConfigCid, balanceNewCid)
+
+        {-
+        Decreases balance of associated account and subtracts new loan from active loans.
+
+        For example: 
+        - Account A with Balance = 1050.0 
+        - LoanConfig with balancePaybackThreshold = 1000.0, activeLoan = 550.0
+        > In this case, account A would be decreased by 50.0 (resulting in a total balance of 1000.0), 
+        > in order to pay back the loan partially and reducing the active loan to 500.0
+        -}
+        choice PaybackLoan: (ContractId LoanConfig, ContractId Balance)
+            with
+                paybackAmount: Optional Amount
+                -- ^ None implies to pay back the max possible
+            controller provider
+                do
+                    (balanceCid, balance) <- getBalance
+                    let maxAmount = currentMaxPaybackAmount balance.amount
+                    let amount = fromOptional maxAmount paybackAmount
+                    assertMsg ("Maximum available payback is: " <> show maxAmount) $ maxAmount >= amount
+                    balanceNewCid <- exercise balanceCid Decrease with decrement = amount
+                    loanConfigCid <- create this with activeLoan = activeLoan - amount
+                    pure (loanConfigCid, balanceNewCid)

--- a/daml-model/daml/Model/LoanConfig.daml
+++ b/daml-model/daml/Model/LoanConfig.daml
@@ -48,10 +48,10 @@ template LoanConfig
         
         let currentMaxLoanAmount balance = min (max (balanceLoanThreshold - balance) 0.0) (maxLoanThreshold - activeLoan)
             currentMaxPaybackAmount balance = min (max (balance - balancePaybackThreshold) 0.0) activeLoan
-            balanceKey = BalanceKey accountHolder account
+            balanceKey = BalanceKey provider account
             getBalance = do
                 visible <- visibleByKey @Balance balanceKey
-                if visible then error $ "No Balance found for BalanceKey: " <> show balanceKey
+                if not visible then error $ "No Balance found for BalanceKey: " <> show balanceKey
                 else do
                     (balanceCid, balance) <- fetchByKey @Balance balanceKey
                     return (balanceCid, balance)
@@ -76,7 +76,7 @@ template LoanConfig
                     (balanceCid, balance) <- getBalance
                     let maxAmount = currentMaxLoanAmount balance.amount
                     let amount = fromOptional maxAmount loanAmount
-                    assertMsg ("Maximum available loan is: " <> show maxAmount) $ maxAmount >= amount
+                    assertMsg ("Maximum available loan is: " <> show maxAmount) $ amount > 0.0 && amount <= maxAmount
                     balanceNewCid <- exercise balanceCid Increase with increment = amount
                     loanConfigCid <- create this with activeLoan = activeLoan + amount
                     pure (loanConfigCid, balanceNewCid)
@@ -99,7 +99,7 @@ template LoanConfig
                     (balanceCid, balance) <- getBalance
                     let maxAmount = currentMaxPaybackAmount balance.amount
                     let amount = fromOptional maxAmount paybackAmount
-                    assertMsg ("Maximum available payback is: " <> show maxAmount) $ maxAmount >= amount
+                    assertMsg ("Maximum available payback is: " <> show maxAmount) $ amount > 0.0 && amount <= maxAmount
                     balanceNewCid <- exercise balanceCid Decrease with decrement = amount
                     loanConfigCid <- create this with activeLoan = activeLoan - amount
                     pure (loanConfigCid, balanceNewCid)

--- a/daml-model/daml/Model/LoanConfig.daml
+++ b/daml-model/daml/Model/LoanConfig.daml
@@ -1,0 +1,47 @@
+--
+-- Copyright (c) 2022, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+--
+
+module Model.LoanConfig where
+
+import Model.Balance
+
+type Amount = Decimal
+type IBAN = Text
+
+-- Loan configuration on account (e.g. IBAN) level
+template LoanConfig
+    with
+        provider: Party
+        accountHolder: Party
+        account: IBAN
+        maxLoan: Amount
+        activeLoan: Amount
+        paybackThreshold: Amount
+        paybackAccount: IBAN
+
+    where
+        signatory provider, accountHolder
+        key (BalanceKey with iban = account, provider = provider) : BalanceKey
+        maintainer key.provider
+
+        ensure activeLoan <= maxLoan
+        
+        let remainingLoanAmount = maxLoan - activeLoan
+            balanceKey = BalanceKey accountHolder account
+
+        choice CreateLoan: (ContractId LoanConfig, ContractId Balance)
+            with
+                loanAmount: Amount
+            controller provider
+                do
+                    assertMsg ("Maximum available loan is: " <> show remainingLoanAmount) $ remainingLoanAmount >= loanAmount
+                    balance <- lookupByKey @Balance balanceKey
+                    case balance of
+                        Some balanceCid -> do
+                            balanceNewCid <- exercise balanceCid Increase with increment = loanAmount
+                            loanConfigCid <- create this with activeLoan = activeLoan + loanAmount
+                            pure (loanConfigCid, balanceNewCid)
+                        None -> error $ "No Balance found for BalanceKey: " <> show balanceKey                  
+    

--- a/daml-model/daml/Model/LoanConfig.daml
+++ b/daml-model/daml/Model/LoanConfig.daml
@@ -75,7 +75,7 @@ template LoanConfig
                 do
                     (balanceCid, balance) <- getBalance
                     let maxAmount = currentMaxLoanAmount balance.amount
-                    let amount = fromOptional maxAmount loanAmount
+                        amount = fromOptional maxAmount loanAmount
                     assertMsg ("Maximum available loan is: " <> show maxAmount) $ amount > 0.0 && amount <= maxAmount
                     balanceNewCid <- exercise balanceCid Increase with increment = amount
                     loanConfigCid <- create this with activeLoan = activeLoan + amount
@@ -98,7 +98,7 @@ template LoanConfig
                 do
                     (balanceCid, balance) <- getBalance
                     let maxAmount = currentMaxPaybackAmount balance.amount
-                    let amount = fromOptional maxAmount paybackAmount
+                        amount = fromOptional maxAmount paybackAmount
                     assertMsg ("Maximum available payback is: " <> show maxAmount) $ amount > 0.0 && amount <= maxAmount
                     balanceNewCid <- exercise balanceCid Decrease with decrement = amount
                     loanConfigCid <- create this with activeLoan = activeLoan - amount

--- a/daml-model/daml/Model/LoanConfig.daml
+++ b/daml-model/daml/Model/LoanConfig.daml
@@ -14,7 +14,7 @@ type IBAN = Text
 {-
 Loan configuration on account (e.g. Provider/IBAN) level
 The idea is to provide the {accountHolder} with individual loans 
-up until {balanceLoanThreshold} is reached and as long as {maxLoanThreshold} 
+up until {balanceLoanThreshold} is reached and as long as {maxLoanSize} 
 has not been reached (as tracked by {activeLoan}).
 -}
 template LoanConfig
@@ -27,7 +27,7 @@ template LoanConfig
         -- ^ Account number
         balanceLoanThreshold: Amount
         -- ^ Defines the balance up until which loans will be provided
-        maxLoanThreshold: Amount
+        maxLoanSize: Amount
         -- ^ Defines the limit of all loans given to this account
         activeLoan: Amount
         -- ^ Sum of currently active loans
@@ -41,12 +41,12 @@ template LoanConfig
         maintainer key.provider
 
         ensure activeLoan >= 0.0
-            && activeLoan <= maxLoanThreshold
+            && activeLoan <= maxLoanSize
             && balanceLoanThreshold >= 0.0
-            && balanceLoanThreshold <= maxLoanThreshold
-            && balancePaybackThreshold > maxLoanThreshold 
+            && balanceLoanThreshold <= maxLoanSize
+            && balancePaybackThreshold > maxLoanSize 
         
-        let currentMaxLoanAmount balance = min (max (balanceLoanThreshold - balance) 0.0) (maxLoanThreshold - activeLoan)
+        let currentMaxLoanAmount balance = min (max (balanceLoanThreshold - balance) 0.0) (maxLoanSize - activeLoan)
             currentMaxPaybackAmount balance = min (max (balance - balancePaybackThreshold) 0.0) activeLoan
             balanceKey = BalanceKey provider account
             getBalance = do
@@ -61,11 +61,11 @@ template LoanConfig
 
         For example: 
         - Account A with Balance = 50.0 
-        - LoanConfig with balanceLoanThreshold = 200.0, maxLoanThreshold = 1000.0, activeLoan = 0.0
+        - LoanConfig with balanceLoanThreshold = 200.0, maxLoanSize = 1000.0, activeLoan = 0.0
         > In this case, account A would be funded with 150.0 (resulting in a total balance of 200.0) 
         > in order to reach the targeted balanceLoanThreshold. Consequently, the new activeLoan = 150.0.
         > In contrast, if prior to the loan giving activeLoan = 1000.0, no loan would be given as 
-        > the maxLoanThreshold has already been reached.
+        > the maxLoanSize has already been reached.
         -}
         choice CreateLoan: (ContractId LoanConfig, ContractId Balance)
             with

--- a/daml-model/daml/Model/LoanConfig.daml
+++ b/daml-model/daml/Model/LoanConfig.daml
@@ -32,8 +32,6 @@ template LoanConfig
         -- ^ Defines at which balance amount the loan will be paid back
 
     where
-        -- TODO: multisig (propose/accept)
-        -- signatory provider, accountHolder
         signatory provider
         observer accountHolder
         key (BalanceKey with iban = account, provider = provider) : BalanceKey
@@ -62,4 +60,4 @@ template LoanConfig
                             loanConfigCid <- create this with activeLoan = activeLoan + amount
                             pure (loanConfigCid, balanceNewCid)
                         None -> error $ "No Balance found for BalanceKey: " <> show balanceKey
-    
+                        

--- a/daml-model/daml/Tests/LoanConfigTest.daml
+++ b/daml-model/daml/Tests/LoanConfigTest.daml
@@ -1,0 +1,300 @@
+--
+-- Copyright (c) 2022, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+--
+
+module Tests.LoanConfigTest where
+
+import DA.Assert
+import Daml.Script
+import Model.Balance
+import Model.LoanConfig
+import Tests.PartyAlloc
+
+setup = do
+    proposalTime <- getTime
+    banks@Banks{..} <- actionPartyAllocation
+    users@UserParties{..} <- userPartyAllocation
+    pure (banks, users)
+
+create_loan_should_increase_balance : Script ()
+create_loan_should_increase_balance = do
+    (Banks{..}, users@UserParties{..}) <- setup
+    submit bank11 do 
+        createCmd Balance with
+            provider = bank11
+            owner = Some users.alice
+            iban = "CH123"
+            currency = "USD"
+            amount = 0.0
+
+    loanConfigCid <- submit bank11 $ do createCmd
+        LoanConfig with
+            provider = bank11
+            accountHolder = users.alice
+            account = "CH123"
+            activeLoan = 0.0
+            balanceLoanThreshold = 1000.0
+            maxLoanThreshold = 10000.0
+            balancePaybackThreshold = 20000.0
+
+    (loanConfigCid, balanceCid) <- submit bank11 do
+        exerciseCmd loanConfigCid CreateLoan with loanAmount = None
+    
+    queryContractId bank11 loanConfigCid >>= optional 
+        (fail "LoanConfig not found") 
+        (\x -> x.activeLoan === 1000.0)
+
+    queryContractId bank11 balanceCid >>= optional 
+        (fail "Balance not found") 
+        (\x -> x.amount === 1000.0)     
+
+create_loan_should_increase_balance_partially : Script ()
+create_loan_should_increase_balance_partially = do
+    (Banks{..}, users@UserParties{..}) <- setup
+    submit bank11 do 
+        createCmd Balance with
+            provider = bank11
+            owner = Some users.alice
+            iban = "CH123"
+            currency = "USD"
+            amount = 0.0
+
+    loanConfigCid <- submit bank11 $ do createCmd
+        LoanConfig with
+            provider = bank11
+            accountHolder = users.alice
+            account = "CH123"
+            activeLoan = 0.0
+            balanceLoanThreshold = 1000.0
+            maxLoanThreshold = 10000.0
+            balancePaybackThreshold = 20000.0
+
+    (loanConfigCid, balanceCid) <- submit bank11 do
+        exerciseCmd loanConfigCid CreateLoan with loanAmount = Some 500.0
+
+    queryContractId bank11 loanConfigCid >>= optional 
+        (fail "LoanConfig not found") 
+        (\x -> x.activeLoan === 500.0) 
+
+    queryContractId bank11 balanceCid >>= optional 
+        (fail "Balance not found") 
+        (\x -> x.amount === 500.0)     
+
+create_loan_should_fail_on_sufficient_balance : Script ()
+create_loan_should_fail_on_sufficient_balance = do
+    (Banks{..}, users@UserParties{..}) <- setup
+    submit bank11 do 
+        createCmd Balance with
+            provider = bank11
+            owner = Some users.alice
+            iban = "CH123"
+            currency = "USD"
+            amount = 1000.0
+    loanConfigCid <- submit bank11 $ do createCmd
+        LoanConfig with
+            provider = bank11
+            accountHolder = users.alice
+            account = "CH123"
+            activeLoan = 0.0
+            balanceLoanThreshold = 1000.0
+            maxLoanThreshold = 10000.0
+            balancePaybackThreshold = 20000.0
+    submitMustFail bank11 do
+        exerciseCmd loanConfigCid CreateLoan with loanAmount = None
+
+create_loan_should_fail_on_exceeded_max_threshold : Script ()
+create_loan_should_fail_on_exceeded_max_threshold = do
+    (Banks{..}, users@UserParties{..}) <- setup
+    submit bank11 do 
+        createCmd Balance with
+            provider = bank11
+            owner = Some users.alice
+            iban = "CH123"
+            currency = "USD"
+            amount = 0.0
+    loanConfigCid <- submit bank11 $ do createCmd
+        LoanConfig with
+            provider = bank11
+            accountHolder = users.alice
+            account = "CH123"
+            activeLoan = 10000.0
+            balanceLoanThreshold = 1000.0
+            maxLoanThreshold = 10000.0
+            balancePaybackThreshold = 20000.0
+    submitMustFail bank11 do
+        exerciseCmd loanConfigCid CreateLoan with loanAmount = None
+
+create_loan_should_fail_on_partially_exceeded_max_threshold : Script ()
+create_loan_should_fail_on_partially_exceeded_max_threshold = do
+    (Banks{..}, users@UserParties{..}) <- setup
+    submit bank11 do 
+        createCmd Balance with
+            provider = bank11
+            owner = Some users.alice
+            iban = "CH123"
+            currency = "USD"
+            amount = 0.0
+    loanConfigCid <- submit bank11 $ do createCmd
+        LoanConfig with
+            provider = bank11
+            accountHolder = users.alice
+            account = "CH123"
+            activeLoan = 9500.0
+            balanceLoanThreshold = 1000.0
+            maxLoanThreshold = 10000.0
+            balancePaybackThreshold = 20000.0
+    submitMustFail bank11 do
+        exerciseCmd loanConfigCid CreateLoan with loanAmount = Some 1000.0
+
+create_payback_should_decrease_on_sufficient_balance : Script ()
+create_payback_should_decrease_on_sufficient_balance = do
+    (Banks{..}, users@UserParties{..}) <- setup
+    submit bank11 do 
+        createCmd Balance with
+            provider = bank11
+            owner = Some users.alice
+            iban = "CH123"
+            currency = "USD"
+            amount = 21000.0
+
+    loanConfigCid <- submit bank11 $ do createCmd
+        LoanConfig with
+            provider = bank11
+            accountHolder = users.alice
+            account = "CH123"
+            activeLoan = 1000.0
+            balanceLoanThreshold = 1000.0
+            maxLoanThreshold = 10000.0
+            balancePaybackThreshold = 20000.0
+
+    (loanConfigCid, balanceCid) <- submit bank11 do
+        exerciseCmd loanConfigCid PaybackLoan with paybackAmount = None
+    
+    queryContractId bank11 loanConfigCid >>= optional 
+        (fail "LoanConfig not found") 
+        (\x -> x.activeLoan === 0.0) 
+
+    queryContractId bank11 balanceCid >>= optional 
+        (fail "Balance not found") 
+        (\x -> x.amount === 20000.0)   
+
+create_payback_should_decrease_on_sufficient_balance_partially : Script ()
+create_payback_should_decrease_on_sufficient_balance_partially = do
+    (Banks{..}, users@UserParties{..}) <- setup
+    submit bank11 do 
+        createCmd Balance with
+            provider = bank11
+            owner = Some users.alice
+            iban = "CH123"
+            currency = "USD"
+            amount = 21000.0
+
+    loanConfigCid <- submit bank11 $ do createCmd
+        LoanConfig with
+            provider = bank11
+            accountHolder = users.alice
+            account = "CH123"
+            activeLoan = 1000.0
+            balanceLoanThreshold = 1000.0
+            maxLoanThreshold = 10000.0
+            balancePaybackThreshold = 20000.0
+
+    (loanConfigCid, balanceCid) <- submit bank11 do
+        exerciseCmd loanConfigCid PaybackLoan with paybackAmount = Some 500.0
+    
+    queryContractId bank11 loanConfigCid >>= optional 
+        (fail "LoanConfig not found") 
+        (\x -> x.activeLoan === 500.0) 
+
+    queryContractId bank11 balanceCid >>= optional 
+        (fail "Balance not found") 
+        (\x -> x.amount === 20500.0)   
+
+create_payback_should_fail_on_insufficient_balance : Script ()
+create_payback_should_fail_on_insufficient_balance = do
+    (Banks{..}, users@UserParties{..}) <- setup
+    submit bank11 do 
+        createCmd Balance with
+            provider = bank11
+            owner = Some users.alice
+            iban = "CH123"
+            currency = "USD"
+            amount = 0.0
+    loanConfigCid <- submit bank11 $ do createCmd
+        LoanConfig with
+            provider = bank11
+            accountHolder = users.alice
+            account = "CH123"
+            activeLoan = 1000.0
+            balanceLoanThreshold = 1000.0
+            maxLoanThreshold = 10000.0
+            balancePaybackThreshold = 20000.0
+    submitMustFail bank11 do
+        exerciseCmd loanConfigCid PaybackLoan with paybackAmount = None
+
+create_payback_should_fail_on_partially_insufficient_balance : Script ()
+create_payback_should_fail_on_partially_insufficient_balance = do
+    (Banks{..}, users@UserParties{..}) <- setup
+    submit bank11 do 
+        createCmd Balance with
+            provider = bank11
+            owner = Some users.alice
+            iban = "CH123"
+            currency = "USD"
+            amount = 20500.0
+    loanConfigCid <- submit bank11 $ do createCmd
+        LoanConfig with
+            provider = bank11
+            accountHolder = users.alice
+            account = "CH123"
+            activeLoan = 1000.0
+            balanceLoanThreshold = 1000.0
+            maxLoanThreshold = 10000.0
+            balancePaybackThreshold = 20000.0
+    submitMustFail bank11 do
+        exerciseCmd loanConfigCid PaybackLoan with paybackAmount = Some 1000.0
+
+create_loan_and_payback_loan_should_reduce_loan : Script ()
+create_loan_and_payback_loan_should_reduce_loan = do
+    (Banks{..}, users@UserParties{..}) <- setup
+    submit bank11 do 
+        createCmd Balance with
+            provider = bank11
+            owner = Some users.alice
+            iban = "CH123"
+            currency = "USD"
+            amount = 0.0
+
+    loanConfigCid <- submit bank11 $ do createCmd
+        LoanConfig with
+            provider = bank11
+            accountHolder = users.alice
+            account = "CH123"
+            activeLoan = 0.0
+            balanceLoanThreshold = 1000.0
+            maxLoanThreshold = 10000.0
+            balancePaybackThreshold = 20000.0
+
+    (loanConfigCid, balanceCid) <- submit bank11 do
+        exerciseCmd loanConfigCid CreateLoan with loanAmount = None
+
+    balanceCid <- submit bank11 do 
+        exerciseCmd balanceCid Decrease with decrement = 100.0
+
+    (loanConfigCid, balanceCid) <- submit bank11 do
+        exerciseCmd loanConfigCid CreateLoan with loanAmount = None
+
+    balanceCid <- submit bank11 do 
+        exerciseCmd balanceCid Increase with increment = 20000.0
+
+    (loanConfigCid, balanceCid) <- submit bank11 do
+        exerciseCmd loanConfigCid PaybackLoan with paybackAmount = None
+
+    queryContractId bank11 loanConfigCid >>= optional 
+        (fail "LoanConfig not found") 
+        (\x -> x.activeLoan === 100.0) 
+
+    queryContractId bank11 balanceCid >>= optional 
+        (fail "Balance not found") 
+        (\x -> x.amount === 20000.0)

--- a/daml-model/daml/Tests/LoanConfigTest.daml
+++ b/daml-model/daml/Tests/LoanConfigTest.daml
@@ -33,7 +33,7 @@ create_loan_should_increase_balance = do
         account = "CH123"
         activeLoan = 0.0
         balanceLoanThreshold = 1000.0
-        maxLoanThreshold = 10000.0
+        maxLoanSize = 10000.0
         balancePaybackThreshold = 20000.0
 
     (loanConfigCid, balanceCid) <- submit bank11 $
@@ -63,7 +63,7 @@ create_loan_should_increase_balance_partially = do
         account = "CH123"
         activeLoan = 0.0
         balanceLoanThreshold = 1000.0
-        maxLoanThreshold = 10000.0
+        maxLoanSize = 10000.0
         balancePaybackThreshold = 20000.0
 
     (loanConfigCid, balanceCid) <- submit bank11 $
@@ -92,7 +92,7 @@ create_loan_should_fail_on_balance_above_loan_threshold = do
         account = "CH123"
         activeLoan = 0.0
         balanceLoanThreshold = 1000.0
-        maxLoanThreshold = 10000.0
+        maxLoanSize = 10000.0
         balancePaybackThreshold = 20000.0
     submitMustFail bank11 $
         exerciseCmd loanConfigCid CreateLoan with loanAmount = None
@@ -112,7 +112,7 @@ create_loan_should_fail_on_exceeded_max_threshold = do
         account = "CH123"
         activeLoan = 10000.0
         balanceLoanThreshold = 1000.0
-        maxLoanThreshold = 10000.0
+        maxLoanSize = 10000.0
         balancePaybackThreshold = 20000.0
     submitMustFail bank11 $
         exerciseCmd loanConfigCid CreateLoan with loanAmount = None
@@ -132,7 +132,7 @@ create_loan_should_fail_on_partially_exceeded_max_threshold = do
         account = "CH123"
         activeLoan = 9500.0
         balanceLoanThreshold = 1000.0
-        maxLoanThreshold = 10000.0
+        maxLoanSize = 10000.0
         balancePaybackThreshold = 20000.0
     submitMustFail bank11 $
         exerciseCmd loanConfigCid CreateLoan with loanAmount = Some 1000.0
@@ -153,7 +153,7 @@ create_payback_should_decrease_on_sufficient_balance = do
         account = "CH123"
         activeLoan = 1000.0
         balanceLoanThreshold = 1000.0
-        maxLoanThreshold = 10000.0
+        maxLoanSize = 10000.0
         balancePaybackThreshold = 20000.0
 
     (loanConfigCid, balanceCid) <- submit bank11 $
@@ -183,7 +183,7 @@ create_payback_should_decrease_on_sufficient_balance_partially = do
         account = "CH123"
         activeLoan = 1000.0
         balanceLoanThreshold = 1000.0
-        maxLoanThreshold = 10000.0
+        maxLoanSize = 10000.0
         balancePaybackThreshold = 20000.0
 
     (loanConfigCid, balanceCid) <- submit bank11 $
@@ -212,7 +212,7 @@ create_payback_should_fail_on_insufficient_balance = do
         account = "CH123"
         activeLoan = 1000.0
         balanceLoanThreshold = 1000.0
-        maxLoanThreshold = 10000.0
+        maxLoanSize = 10000.0
         balancePaybackThreshold = 20000.0
     submitMustFail bank11 $
         exerciseCmd loanConfigCid PaybackLoan with paybackAmount = None
@@ -233,7 +233,7 @@ create_payback_should_fail_on_partially_insufficient_balance = do
             account = "CH123"
             activeLoan = 1000.0
             balanceLoanThreshold = 1000.0
-            maxLoanThreshold = 10000.0
+            maxLoanSize = 10000.0
             balancePaybackThreshold = 20000.0
     submitMustFail bank11 do
         exerciseCmd loanConfigCid PaybackLoan with paybackAmount = Some 1000.0
@@ -254,7 +254,7 @@ create_loan_and_payback_loan_should_reduce_loan = do
         account = "CH123"
         activeLoan = 0.0
         balanceLoanThreshold = 1000.0
-        maxLoanThreshold = 10000.0
+        maxLoanSize = 10000.0
         balancePaybackThreshold = 20000.0
 
     (loanConfigCid, balanceCid) <- submit bank11 $

--- a/daml-model/daml/Tests/LoanConfigTest.daml
+++ b/daml-model/daml/Tests/LoanConfigTest.daml
@@ -20,25 +20,23 @@ setup = do
 create_loan_should_increase_balance : Script ()
 create_loan_should_increase_balance = do
     (Banks{..}, users@UserParties{..}) <- setup
-    submit bank11 do 
-        createCmd Balance with
-            provider = bank11
-            owner = Some users.alice
-            iban = "CH123"
-            currency = "USD"
-            amount = 0.0
+    submit bank11 $ createCmd Balance with
+        provider = bank11
+        owner = Some users.alice
+        iban = "CH123"
+        currency = "USD"
+        amount = 0.0
 
-    loanConfigCid <- submit bank11 $ do createCmd
-        LoanConfig with
-            provider = bank11
-            accountHolder = users.alice
-            account = "CH123"
-            activeLoan = 0.0
-            balanceLoanThreshold = 1000.0
-            maxLoanThreshold = 10000.0
-            balancePaybackThreshold = 20000.0
+    loanConfigCid <- submit bank11 $ createCmd LoanConfig with
+        provider = bank11
+        accountHolder = users.alice
+        account = "CH123"
+        activeLoan = 0.0
+        balanceLoanThreshold = 1000.0
+        maxLoanThreshold = 10000.0
+        balancePaybackThreshold = 20000.0
 
-    (loanConfigCid, balanceCid) <- submit bank11 do
+    (loanConfigCid, balanceCid) <- submit bank11 $
         exerciseCmd loanConfigCid CreateLoan with loanAmount = None
     
     queryContractId bank11 loanConfigCid >>= optional 
@@ -52,25 +50,23 @@ create_loan_should_increase_balance = do
 create_loan_should_increase_balance_partially : Script ()
 create_loan_should_increase_balance_partially = do
     (Banks{..}, users@UserParties{..}) <- setup
-    submit bank11 do 
-        createCmd Balance with
-            provider = bank11
-            owner = Some users.alice
-            iban = "CH123"
-            currency = "USD"
-            amount = 0.0
+    submit bank11 $ createCmd Balance with
+        provider = bank11
+        owner = Some users.alice
+        iban = "CH123"
+        currency = "USD"
+        amount = 0.0
 
-    loanConfigCid <- submit bank11 $ do createCmd
-        LoanConfig with
-            provider = bank11
-            accountHolder = users.alice
-            account = "CH123"
-            activeLoan = 0.0
-            balanceLoanThreshold = 1000.0
-            maxLoanThreshold = 10000.0
-            balancePaybackThreshold = 20000.0
+    loanConfigCid <- submit bank11 $ createCmd LoanConfig with
+        provider = bank11
+        accountHolder = users.alice
+        account = "CH123"
+        activeLoan = 0.0
+        balanceLoanThreshold = 1000.0
+        maxLoanThreshold = 10000.0
+        balancePaybackThreshold = 20000.0
 
-    (loanConfigCid, balanceCid) <- submit bank11 do
+    (loanConfigCid, balanceCid) <- submit bank11 $
         exerciseCmd loanConfigCid CreateLoan with loanAmount = Some 500.0
 
     queryContractId bank11 loanConfigCid >>= optional 
@@ -81,94 +77,86 @@ create_loan_should_increase_balance_partially = do
         (fail "Balance not found") 
         (\x -> x.amount === 500.0)     
 
-create_loan_should_fail_on_sufficient_balance : Script ()
-create_loan_should_fail_on_sufficient_balance = do
+create_loan_should_fail_on_balance_above_loan_threshold : Script ()
+create_loan_should_fail_on_balance_above_loan_threshold = do
     (Banks{..}, users@UserParties{..}) <- setup
-    submit bank11 do 
-        createCmd Balance with
-            provider = bank11
-            owner = Some users.alice
-            iban = "CH123"
-            currency = "USD"
-            amount = 1000.0
-    loanConfigCid <- submit bank11 $ do createCmd
-        LoanConfig with
-            provider = bank11
-            accountHolder = users.alice
-            account = "CH123"
-            activeLoan = 0.0
-            balanceLoanThreshold = 1000.0
-            maxLoanThreshold = 10000.0
-            balancePaybackThreshold = 20000.0
-    submitMustFail bank11 do
+    submit bank11 $ createCmd Balance with
+        provider = bank11
+        owner = Some users.alice
+        iban = "CH123"
+        currency = "USD"
+        amount = 1000.0
+    loanConfigCid <- submit bank11 $ createCmd LoanConfig with
+        provider = bank11
+        accountHolder = users.alice
+        account = "CH123"
+        activeLoan = 0.0
+        balanceLoanThreshold = 1000.0
+        maxLoanThreshold = 10000.0
+        balancePaybackThreshold = 20000.0
+    submitMustFail bank11 $
         exerciseCmd loanConfigCid CreateLoan with loanAmount = None
 
 create_loan_should_fail_on_exceeded_max_threshold : Script ()
 create_loan_should_fail_on_exceeded_max_threshold = do
     (Banks{..}, users@UserParties{..}) <- setup
-    submit bank11 do 
-        createCmd Balance with
-            provider = bank11
-            owner = Some users.alice
-            iban = "CH123"
-            currency = "USD"
-            amount = 0.0
-    loanConfigCid <- submit bank11 $ do createCmd
-        LoanConfig with
-            provider = bank11
-            accountHolder = users.alice
-            account = "CH123"
-            activeLoan = 10000.0
-            balanceLoanThreshold = 1000.0
-            maxLoanThreshold = 10000.0
-            balancePaybackThreshold = 20000.0
-    submitMustFail bank11 do
+    submit bank11 $ createCmd Balance with
+        provider = bank11
+        owner = Some users.alice
+        iban = "CH123"
+        currency = "USD"
+        amount = 0.0
+    loanConfigCid <- submit bank11 $ createCmd LoanConfig with
+        provider = bank11
+        accountHolder = users.alice
+        account = "CH123"
+        activeLoan = 10000.0
+        balanceLoanThreshold = 1000.0
+        maxLoanThreshold = 10000.0
+        balancePaybackThreshold = 20000.0
+    submitMustFail bank11 $
         exerciseCmd loanConfigCid CreateLoan with loanAmount = None
 
 create_loan_should_fail_on_partially_exceeded_max_threshold : Script ()
 create_loan_should_fail_on_partially_exceeded_max_threshold = do
     (Banks{..}, users@UserParties{..}) <- setup
-    submit bank11 do 
-        createCmd Balance with
-            provider = bank11
-            owner = Some users.alice
-            iban = "CH123"
-            currency = "USD"
-            amount = 0.0
-    loanConfigCid <- submit bank11 $ do createCmd
-        LoanConfig with
-            provider = bank11
-            accountHolder = users.alice
-            account = "CH123"
-            activeLoan = 9500.0
-            balanceLoanThreshold = 1000.0
-            maxLoanThreshold = 10000.0
-            balancePaybackThreshold = 20000.0
-    submitMustFail bank11 do
+    submit bank11 $ createCmd Balance with
+        provider = bank11
+        owner = Some users.alice
+        iban = "CH123"
+        currency = "USD"
+        amount = 0.0
+    loanConfigCid <- submit bank11 $ createCmd LoanConfig with
+        provider = bank11
+        accountHolder = users.alice
+        account = "CH123"
+        activeLoan = 9500.0
+        balanceLoanThreshold = 1000.0
+        maxLoanThreshold = 10000.0
+        balancePaybackThreshold = 20000.0
+    submitMustFail bank11 $
         exerciseCmd loanConfigCid CreateLoan with loanAmount = Some 1000.0
 
 create_payback_should_decrease_on_sufficient_balance : Script ()
 create_payback_should_decrease_on_sufficient_balance = do
     (Banks{..}, users@UserParties{..}) <- setup
-    submit bank11 do 
-        createCmd Balance with
-            provider = bank11
-            owner = Some users.alice
-            iban = "CH123"
-            currency = "USD"
-            amount = 21000.0
+    submit bank11 $ createCmd Balance with
+        provider = bank11
+        owner = Some users.alice
+        iban = "CH123"
+        currency = "USD"
+        amount = 21000.0
 
-    loanConfigCid <- submit bank11 $ do createCmd
-        LoanConfig with
-            provider = bank11
-            accountHolder = users.alice
-            account = "CH123"
-            activeLoan = 1000.0
-            balanceLoanThreshold = 1000.0
-            maxLoanThreshold = 10000.0
-            balancePaybackThreshold = 20000.0
+    loanConfigCid <- submit bank11 $ createCmd LoanConfig with
+        provider = bank11
+        accountHolder = users.alice
+        account = "CH123"
+        activeLoan = 1000.0
+        balanceLoanThreshold = 1000.0
+        maxLoanThreshold = 10000.0
+        balancePaybackThreshold = 20000.0
 
-    (loanConfigCid, balanceCid) <- submit bank11 do
+    (loanConfigCid, balanceCid) <- submit bank11 $
         exerciseCmd loanConfigCid PaybackLoan with paybackAmount = None
     
     queryContractId bank11 loanConfigCid >>= optional 
@@ -182,25 +170,23 @@ create_payback_should_decrease_on_sufficient_balance = do
 create_payback_should_decrease_on_sufficient_balance_partially : Script ()
 create_payback_should_decrease_on_sufficient_balance_partially = do
     (Banks{..}, users@UserParties{..}) <- setup
-    submit bank11 do 
-        createCmd Balance with
-            provider = bank11
-            owner = Some users.alice
-            iban = "CH123"
-            currency = "USD"
-            amount = 21000.0
+    submit bank11 $ createCmd Balance with
+        provider = bank11
+        owner = Some users.alice
+        iban = "CH123"
+        currency = "USD"
+        amount = 21000.0
 
-    loanConfigCid <- submit bank11 $ do createCmd
-        LoanConfig with
-            provider = bank11
-            accountHolder = users.alice
-            account = "CH123"
-            activeLoan = 1000.0
-            balanceLoanThreshold = 1000.0
-            maxLoanThreshold = 10000.0
-            balancePaybackThreshold = 20000.0
+    loanConfigCid <- submit bank11 $ createCmd LoanConfig with
+        provider = bank11
+        accountHolder = users.alice
+        account = "CH123"
+        activeLoan = 1000.0
+        balanceLoanThreshold = 1000.0
+        maxLoanThreshold = 10000.0
+        balancePaybackThreshold = 20000.0
 
-    (loanConfigCid, balanceCid) <- submit bank11 do
+    (loanConfigCid, balanceCid) <- submit bank11 $
         exerciseCmd loanConfigCid PaybackLoan with paybackAmount = Some 500.0
     
     queryContractId bank11 loanConfigCid >>= optional 
@@ -214,36 +200,33 @@ create_payback_should_decrease_on_sufficient_balance_partially = do
 create_payback_should_fail_on_insufficient_balance : Script ()
 create_payback_should_fail_on_insufficient_balance = do
     (Banks{..}, users@UserParties{..}) <- setup
-    submit bank11 do 
-        createCmd Balance with
-            provider = bank11
-            owner = Some users.alice
-            iban = "CH123"
-            currency = "USD"
-            amount = 0.0
-    loanConfigCid <- submit bank11 $ do createCmd
-        LoanConfig with
-            provider = bank11
-            accountHolder = users.alice
-            account = "CH123"
-            activeLoan = 1000.0
-            balanceLoanThreshold = 1000.0
-            maxLoanThreshold = 10000.0
-            balancePaybackThreshold = 20000.0
-    submitMustFail bank11 do
+    submit bank11 $ createCmd Balance with
+        provider = bank11
+        owner = Some users.alice
+        iban = "CH123"
+        currency = "USD"
+        amount = 0.0
+    loanConfigCid <- submit bank11 $ createCmd LoanConfig with
+        provider = bank11
+        accountHolder = users.alice
+        account = "CH123"
+        activeLoan = 1000.0
+        balanceLoanThreshold = 1000.0
+        maxLoanThreshold = 10000.0
+        balancePaybackThreshold = 20000.0
+    submitMustFail bank11 $
         exerciseCmd loanConfigCid PaybackLoan with paybackAmount = None
 
 create_payback_should_fail_on_partially_insufficient_balance : Script ()
 create_payback_should_fail_on_partially_insufficient_balance = do
     (Banks{..}, users@UserParties{..}) <- setup
-    submit bank11 do 
-        createCmd Balance with
-            provider = bank11
-            owner = Some users.alice
-            iban = "CH123"
-            currency = "USD"
-            amount = 20500.0
-    loanConfigCid <- submit bank11 $ do createCmd
+    submit bank11 $ createCmd Balance with
+        provider = bank11
+        owner = Some users.alice
+        iban = "CH123"
+        currency = "USD"
+        amount = 20500.0
+    loanConfigCid <- submit bank11 $ createCmd
         LoanConfig with
             provider = bank11
             accountHolder = users.alice
@@ -258,37 +241,35 @@ create_payback_should_fail_on_partially_insufficient_balance = do
 create_loan_and_payback_loan_should_reduce_loan : Script ()
 create_loan_and_payback_loan_should_reduce_loan = do
     (Banks{..}, users@UserParties{..}) <- setup
-    submit bank11 do 
-        createCmd Balance with
-            provider = bank11
-            owner = Some users.alice
-            iban = "CH123"
-            currency = "USD"
-            amount = 0.0
+    submit bank11 $ createCmd Balance with
+        provider = bank11
+        owner = Some users.alice
+        iban = "CH123"
+        currency = "USD"
+        amount = 0.0
 
-    loanConfigCid <- submit bank11 $ do createCmd
-        LoanConfig with
-            provider = bank11
-            accountHolder = users.alice
-            account = "CH123"
-            activeLoan = 0.0
-            balanceLoanThreshold = 1000.0
-            maxLoanThreshold = 10000.0
-            balancePaybackThreshold = 20000.0
+    loanConfigCid <- submit bank11 $ createCmd LoanConfig with
+        provider = bank11
+        accountHolder = users.alice
+        account = "CH123"
+        activeLoan = 0.0
+        balanceLoanThreshold = 1000.0
+        maxLoanThreshold = 10000.0
+        balancePaybackThreshold = 20000.0
 
-    (loanConfigCid, balanceCid) <- submit bank11 do
+    (loanConfigCid, balanceCid) <- submit bank11 $
         exerciseCmd loanConfigCid CreateLoan with loanAmount = None
 
-    balanceCid <- submit bank11 do 
+    balanceCid <- submit bank11 $
         exerciseCmd balanceCid Decrease with decrement = 100.0
 
-    (loanConfigCid, balanceCid) <- submit bank11 do
+    (loanConfigCid, balanceCid) <- submit bank11 $
         exerciseCmd loanConfigCid CreateLoan with loanAmount = None
 
-    balanceCid <- submit bank11 do 
+    balanceCid <- submit bank11 $
         exerciseCmd balanceCid Increase with increment = 20000.0
 
-    (loanConfigCid, balanceCid) <- submit bank11 do
+    (loanConfigCid, balanceCid) <- submit bank11 $
         exerciseCmd loanConfigCid PaybackLoan with paybackAmount = None
 
     queryContractId bank11 loanConfigCid >>= optional 

--- a/daml-model/daml/Tests/LoanManagementTest.daml
+++ b/daml-model/daml/Tests/LoanManagementTest.daml
@@ -1,0 +1,81 @@
+module Tests.LoanManagementTest where
+
+import Trigger.LoanManagement
+import Daml.Trigger.Assert (toACS, testRule, flattenCommands, assertExerciseCmd)
+import Daml.Script
+import Tests.PartyAlloc
+import Model.Balance
+import Model.LoanConfig
+import qualified DA.Map as M
+import Daml.Trigger (Command)
+
+
+setup = do
+    proposalTime <- getTime
+    banks@Banks{..} <- actionPartyAllocation
+    schedulerAndAssembler@ServiceParties{..} <- servicePartyAllocation
+    users@UserParties{..} <- userPartyAllocation
+
+    let approvers = [cb, bank11, bank12, bank21, bank22]
+    pure (banks, schedulerAndAssembler, users)
+
+
+createLoanWithMaxLoanPerTransaction : Script ()
+createLoanWithMaxLoanPerTransaction = do
+    (Banks{..}, ServiceParties{..}, users@UserParties{..}) <- setup
+    aliceBalanceCid <- submit bank11 do 
+        createCmd Balance with 
+            provider = bank11
+            owner = Some users.alice
+            iban = "CH123"
+            currency = "USD"
+            amount = 0.0
+
+    loanConfigCid <- submit bank11 $ do createCmd
+        LoanConfig with
+            provider = bank11
+            accountHolder = users.alice
+            account = "CH123"
+            activeLoan = 0.0
+            maxLoanPerTransaction = 1000.0
+            maxLoanThreshold = 10000.0
+            paybackThreshold = None
+
+    commands <- getTriggerResults bank11 loanConfigCid aliceBalanceCid
+
+    verifyCommandsCount commands 1
+    verifyLoanAmount loanConfigCid commands (Some 1000.0)
+    -- verifyBalance aliceBalanceCid commands 1000.0
+
+
+-- Helper functions
+
+getTriggerResults: Party -> ContractId LoanConfig -> ContractId Balance -> Script [Command]
+getTriggerResults triggerParty loanConfigCid balanceCid = do
+  let marker = optional mempty toACS $ Some loanConfigCid
+      acs = marker <> toACS balanceCid
+  (flattenCommands . snd) <$> testRule loanManagementTrigger triggerParty [] acs M.empty ()
+
+verifyLoanAmount: ContractId LoanConfig -> [Command] -> Optional Decimal -> Script ()
+verifyLoanAmount loanConfigCid commands amount = do
+  assertExerciseCmd commands $ \(cid, exercisedChoice) -> do
+    assertMsg "ContractId used in exercise is incorrect" $ cid == loanConfigCid
+    case exercisedChoice of
+      CreateLoan a | a == amount -> Right ()
+      CreateLoan a | a /= amount -> Left $ "Wrong loan amount provided. Expected: " <> show amount <> " but granted " <> show a
+      _ -> Left $ "Did not settle on ledger"
+
+verifyBalance: ContractId Balance -> [Command] -> Decimal -> Script ()
+verifyBalance balanceCid commands amount = do
+  assertExerciseCmd commands $ \(cid, exercisedChoice) -> do
+    assertMsg "ContractId used in exercise is incorrect" $ cid == balanceCid
+    case exercisedChoice of
+      Increase a | a == amount -> Right ()
+      Increase a | a /= amount -> Left $ "Wrong balance increase. Expected: " <> show amount <> " but granted " <> show a
+      _ -> Left $ "Did not settle on ledger"
+
+verifyCommandsCount: [Command] -> Int -> Script ()
+verifyCommandsCount commands expected = do
+    assertMsg ("Expected " <> show expected <> " but got " <> show len) $ len == expected 
+    where len = length commands
+    

--- a/daml-model/daml/Tests/LoanManagementTest.daml
+++ b/daml-model/daml/Tests/LoanManagementTest.daml
@@ -19,7 +19,6 @@ setup = do
     let approvers = [cb, bank11, bank12, bank21, bank22]
     pure (banks, schedulerAndAssembler, users)
 
-
 createLoanWithMaxLoanPerTransaction : Script ()
 createLoanWithMaxLoanPerTransaction = do
     (Banks{..}, ServiceParties{..}, users@UserParties{..}) <- setup
@@ -44,8 +43,7 @@ createLoanWithMaxLoanPerTransaction = do
     commands <- getTriggerResults bank11 loanConfigCid aliceBalanceCid
 
     verifyCommandsCount commands 1
-    verifyLoanAmount loanConfigCid commands (Some 1000.0)
-    -- verifyBalance aliceBalanceCid commands 1000.0
+    verifyLoanAmount loanConfigCid commands None
 
 
 -- Helper functions
@@ -63,15 +61,6 @@ verifyLoanAmount loanConfigCid commands amount = do
     case exercisedChoice of
       CreateLoan a | a == amount -> Right ()
       CreateLoan a | a /= amount -> Left $ "Wrong loan amount provided. Expected: " <> show amount <> " but granted " <> show a
-      _ -> Left $ "Did not settle on ledger"
-
-verifyBalance: ContractId Balance -> [Command] -> Decimal -> Script ()
-verifyBalance balanceCid commands amount = do
-  assertExerciseCmd commands $ \(cid, exercisedChoice) -> do
-    assertMsg "ContractId used in exercise is incorrect" $ cid == balanceCid
-    case exercisedChoice of
-      Increase a | a == amount -> Right ()
-      Increase a | a /= amount -> Left $ "Wrong balance increase. Expected: " <> show amount <> " but granted " <> show a
       _ -> Left $ "Did not settle on ledger"
 
 verifyCommandsCount: [Command] -> Int -> Script ()

--- a/daml-model/daml/Tests/LoanManagementTest.daml
+++ b/daml-model/daml/Tests/LoanManagementTest.daml
@@ -1,3 +1,8 @@
+--
+-- Copyright (c) 2022, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+--
+
 module Tests.LoanManagementTest where
 
 import Trigger.LoanManagement
@@ -19,11 +24,11 @@ setup = do
     let approvers = [cb, bank11, bank12, bank21, bank22]
     pure (banks, schedulerAndAssembler, users)
 
-createLoanWithMaxLoanPerTransaction : Script ()
-createLoanWithMaxLoanPerTransaction = do
+given_balance_below_threshold_then_create_loan : Script ()
+given_balance_below_threshold_then_create_loan = do
     (Banks{..}, ServiceParties{..}, users@UserParties{..}) <- setup
-    aliceBalanceCid <- submit bank11 do 
-        createCmd Balance with 
+    aliceBalanceCid <- submit bank11 do
+        createCmd Balance with
             provider = bank11
             owner = Some users.alice
             iban = "CH123"
@@ -41,10 +46,57 @@ createLoanWithMaxLoanPerTransaction = do
             balancePaybackThreshold = 20000.0
 
     commands <- getTriggerResults bank11 loanConfigCid aliceBalanceCid
-
     verifyCommandsCount commands 1
     verifyLoanAmount loanConfigCid commands None
 
+given_balance_above_threshold_then_create_payback : Script ()
+given_balance_above_threshold_then_create_payback = do
+    (Banks{..}, ServiceParties{..}, users@UserParties{..}) <- setup
+    aliceBalanceCid <- submit bank11 do
+        createCmd Balance with
+            provider = bank11
+            owner = Some users.alice
+            iban = "CH123"
+            currency = "USD"
+            amount = 21000.0
+
+    loanConfigCid <- submit bank11 $ do createCmd
+        LoanConfig with
+            provider = bank11
+            accountHolder = users.alice
+            account = "CH123"
+            activeLoan = 0.0
+            balanceLoanThreshold = 1000.0
+            maxLoanThreshold = 10000.0
+            balancePaybackThreshold = 20000.0
+
+    commands <- getTriggerResults bank11 loanConfigCid aliceBalanceCid
+    verifyCommandsCount commands 1
+    verifyPaybackAmount loanConfigCid commands None
+
+given_balance_at_threshold_then_create_no_loan_and_no_payback : Script ()
+given_balance_at_threshold_then_create_no_loan_and_no_payback = do
+    (Banks{..}, ServiceParties{..}, users@UserParties{..}) <- setup
+    aliceBalanceCid <- submit bank11 do
+        createCmd Balance with
+            provider = bank11
+            owner = Some users.alice
+            iban = "CH123"
+            currency = "USD"
+            amount = 10000.0
+
+    loanConfigCid <- submit bank11 $ do createCmd
+        LoanConfig with
+            provider = bank11
+            accountHolder = users.alice
+            account = "CH123"
+            activeLoan = 0.0
+            balanceLoanThreshold = 1000.0
+            maxLoanThreshold = 10000.0
+            balancePaybackThreshold = 20000.0
+
+    commands <- getTriggerResults bank11 loanConfigCid aliceBalanceCid
+    verifyCommandsCount commands 0
 
 -- Helper functions
 
@@ -61,6 +113,15 @@ verifyLoanAmount loanConfigCid commands amount = do
     case exercisedChoice of
       CreateLoan a | a == amount -> Right ()
       CreateLoan a | a /= amount -> Left $ "Wrong loan amount provided. Expected: " <> show amount <> " but granted " <> show a
+      _ -> Left $ "Did not settle on ledger"
+
+verifyPaybackAmount: ContractId LoanConfig -> [Command] -> Optional Decimal -> Script ()
+verifyPaybackAmount loanConfigCid commands amount = do
+  assertExerciseCmd commands $ \(cid, exercisedChoice) -> do
+    assertMsg "ContractId used in exercise is incorrect" $ cid == loanConfigCid
+    case exercisedChoice of
+      PaybackLoan a | a == amount -> Right ()
+      PaybackLoan a | a /= amount -> Left $ "Wrong payback amount provided. Expected: " <> show amount <> " but granted " <> show a
       _ -> Left $ "Did not settle on ledger"
 
 verifyCommandsCount: [Command] -> Int -> Script ()

--- a/daml-model/daml/Tests/LoanManagementTest.daml
+++ b/daml-model/daml/Tests/LoanManagementTest.daml
@@ -42,7 +42,7 @@ given_balance_below_threshold_then_create_loan = do
             account = "CH123"
             activeLoan = 0.0
             balanceLoanThreshold = 1000.0
-            maxLoanThreshold = 10000.0
+            maxLoanSize = 10000.0
             balancePaybackThreshold = 20000.0
 
     commands <- getTriggerResults bank11 loanConfigCid aliceBalanceCid
@@ -67,7 +67,7 @@ given_balance_above_threshold_then_create_payback = do
             account = "CH123"
             activeLoan = 0.0
             balanceLoanThreshold = 1000.0
-            maxLoanThreshold = 10000.0
+            maxLoanSize = 10000.0
             balancePaybackThreshold = 20000.0
 
     commands <- getTriggerResults bank11 loanConfigCid aliceBalanceCid
@@ -92,7 +92,7 @@ given_balance_at_threshold_then_create_no_loan_and_no_payback = do
             account = "CH123"
             activeLoan = 0.0
             balanceLoanThreshold = 1000.0
-            maxLoanThreshold = 10000.0
+            maxLoanSize = 10000.0
             balancePaybackThreshold = 20000.0
 
     commands <- getTriggerResults bank11 loanConfigCid aliceBalanceCid

--- a/daml-model/daml/Tests/LoanManagementTest.daml
+++ b/daml-model/daml/Tests/LoanManagementTest.daml
@@ -36,9 +36,9 @@ createLoanWithMaxLoanPerTransaction = do
             accountHolder = users.alice
             account = "CH123"
             activeLoan = 0.0
-            maxLoanPerTransaction = 1000.0
+            balanceLoanThreshold = 1000.0
             maxLoanThreshold = 10000.0
-            paybackThreshold = None
+            balancePaybackThreshold = 20000.0
 
     commands <- getTriggerResults bank11 loanConfigCid aliceBalanceCid
 

--- a/daml-model/daml/Tests/PartyAlloc.daml
+++ b/daml-model/daml/Tests/PartyAlloc.daml
@@ -17,6 +17,10 @@ data Banks = Banks with
 data ServiceParties = ServiceParties with
   scheduler : Party
   assembler: Party
+
+data UserParties = UserParties with
+  alice : Party
+
 actionPartyAllocation = do
   bank21 <- allocateParty "Bank21"
   bank11 <- allocateParty "Bank11"
@@ -31,3 +35,7 @@ servicePartyAllocation = do
   assembler <- allocateParty "Assembler"
 
   pure ServiceParties with ..
+
+userPartyAllocation = do
+  alice <- allocateParty "Alice"
+  pure UserParties with ..

--- a/daml-model/daml/Trigger/AutoApprove.daml
+++ b/daml-model/daml/Trigger/AutoApprove.daml
@@ -8,12 +8,13 @@
 module Trigger.AutoApprove where
 
 import DA.Action (void, when)
-import DA.Foldable (forA_)
+import DA.Foldable (mapA_, forA_)
 import DA.List (head)
 import DA.Optional (fromSome, optionalToList)
 import Daml.Trigger
 import Model.Blacklist
 import Model.Balance
+import Model.LoanConfig
 import Workflow.TransferProposal
 import Workflow.Data
 import DA.Map qualified as Map
@@ -27,7 +28,8 @@ autoApproveTrigger = Trigger
       registeredTemplate @AutoApproveTransferProposalMarker,
       registeredTemplate @TransferProposal,
       registeredTemplate @Blacklist,
-      registeredTemplate @Balance
+      registeredTemplate @Balance,
+      registeredTemplate @LoanConfig
     ]
   , heartbeat = None
   }
@@ -105,25 +107,6 @@ involveBlackListParty TransferProposal{step, approvers} Blacklist{banks, account
   let bankOnSettlementChainBlackListed = any (`elem` banks) approvers in
   receiverIsBlackListed || senderIsBlackListed || bankOnSettlementChainBlackListed
 
-type HasEnoughBalanceWithBalanceCid = (Bool, Optional (ContractId Balance))
-hasEnoughBalance : TransferProposal -> TriggerA () HasEnoughBalanceWithBalanceCid
-hasEnoughBalance transferProposal@TransferProposal{owner; step} = do
-  let
-    Instrument{amount, label} = step.delivery
-    amountRequired = amount
-    currencyRequired = label
-    identifier = toIdentifier transferProposal
-    provider = owner
-  case step.sender of
-    Some iban -> do
-      queryContractKey (BalanceKey with ..) >>= \case
-        Some (balanceCid, Balance{amount;currency}) ->
-          if currency /= currencyRequired then
-            pure $ trace ("Account " <> iban <> "does not hold required currency " <> currencyRequired) (False, Some balanceCid)
-          else pure $ (amount >= amountRequired, Some balanceCid)
-        None -> pure $ trace ("No Balance exist for account" <> iban) (False, None)
-    None -> pure (True, None)
-
 findProposalMarker : TransferProposal -> Map.Map Text AutoApproveTransferProposalMarker -> Optional AutoApproveTransferProposalMarker
 findProposalMarker transferProposal@TransferProposal{ step = SettlementStep{ sender, receiver } } markers =
   case (sender, receiver) of
@@ -154,21 +137,45 @@ findBalance transferProposal@TransferProposal{owner; step} iban = do
       else pure $ Some balance
     None -> pure $ trace ("No Balance exist for account" <> iban) None
 
+createLoanForSender : TransferProposal -> Decimal -> Text -> ContractId TransferProposal -> TriggerA () ()
+createLoanForSender transferProposal loanAmount sender cid = do
+  case transferProposal.step.sender of
+    Some sender -> do
+      let balanceKey = BalanceKey with iban = sender, provider = transferProposal.owner
+      loanConfig <- queryContractKey @LoanConfig balanceKey
+      case loanConfig of
+        Some (loanConfigCid, lc) -> do
+          let cmd = exerciseCmd loanConfigCid (CreateLoan with loanAmount = loanAmount)
+          void $ emitCommands [cmd] [toAnyContractId cid] 
+        None -> pure $ trace ("No LoanConfig found for BalanceKey" <> show balanceKey) ()
+    None -> pure $ trace "Unable request loan for empty sender"  ()
+
+
 handleProposalForSender : TransferProposal -> Text -> Blacklist -> ContractId TransferProposal -> TriggerA () ()
 handleProposalForSender transferProposal sender blacklist cid = do
-  maybeBalance <- findBalance transferProposal sender
-  case maybeBalance of
-    Some (balanceCid, balance) | transferProposal.step.delivery.amount <= balance.amount ->
-        if involveBlackListParty transferProposal blacklist then
-          rejectProposal "Rejected due to blacklist" cid
-        else
-          approveProposal
-            "Approved Proposal as sender has enough balance and no banks/accounts are blacklisted"
-            cid
-            (Some balanceCid)
-            (lockBalanceCommand transferProposal balanceCid)
-    _ ->
-      rejectProposal "Rejected due to not enough balance"  cid
+  if involveBlackListParty transferProposal blacklist then
+      rejectProposal "Rejected due to blacklist" cid
+  else do
+    maybeBalance <- findBalance transferProposal sender
+    mapA_ (\(balanceCid, balance) -> do
+          if transferProposal.step.delivery.amount <= balance.amount then do
+            let loanAmount = transferProposal.step.delivery.amount - balance.amount
+            createLoanForSender transferProposal loanAmount sender cid
+            maybeBalance <- findBalance transferProposal sender
+            pure ()
+          else
+            pure ()
+      ) maybeBalance
+    
+    case maybeBalance of
+      Some (balanceCid, balance) | transferProposal.step.delivery.amount <= balance.amount ->
+        approveProposal
+          "Approved Proposal as sender has enough balance and no banks/accounts are blacklisted"
+          cid
+          (Some balanceCid)
+          (lockBalanceCommand transferProposal balanceCid)
+      _ ->
+        rejectProposal "Rejected due to not enough balance"  cid
 
 handleProposalForReceiver : TransferProposal -> ContractId TransferProposal -> TriggerA () ()
 handleProposalForReceiver transferProposal cid = do

--- a/daml-model/daml/Trigger/AutoApprove.daml
+++ b/daml-model/daml/Trigger/AutoApprove.daml
@@ -137,45 +137,21 @@ findBalance transferProposal@TransferProposal{owner; step} iban = do
       else pure $ Some balance
     None -> pure $ trace ("No Balance exist for account" <> iban) None
 
-createLoanForSender : TransferProposal -> Decimal -> Text -> ContractId TransferProposal -> TriggerA () ()
-createLoanForSender transferProposal loanAmount sender cid = do
-  case transferProposal.step.sender of
-    Some sender -> do
-      let balanceKey = BalanceKey with iban = sender, provider = transferProposal.owner
-      loanConfig <- queryContractKey @LoanConfig balanceKey
-      case loanConfig of
-        Some (loanConfigCid, lc) -> do
-          let cmd = exerciseCmd loanConfigCid (CreateLoan with loanAmount = loanAmount)
-          void $ emitCommands [cmd] [toAnyContractId cid] 
-        None -> pure $ trace ("No LoanConfig found for BalanceKey" <> show balanceKey) ()
-    None -> pure $ trace "Unable request loan for empty sender"  ()
-
-
 handleProposalForSender : TransferProposal -> Text -> Blacklist -> ContractId TransferProposal -> TriggerA () ()
 handleProposalForSender transferProposal sender blacklist cid = do
-  if involveBlackListParty transferProposal blacklist then
-      rejectProposal "Rejected due to blacklist" cid
-  else do
-    maybeBalance <- findBalance transferProposal sender
-    mapA_ (\(balanceCid, balance) -> do
-          if transferProposal.step.delivery.amount <= balance.amount then do
-            let loanAmount = transferProposal.step.delivery.amount - balance.amount
-            createLoanForSender transferProposal loanAmount sender cid
-            maybeBalance <- findBalance transferProposal sender
-            pure ()
-          else
-            pure ()
-      ) maybeBalance
-    
-    case maybeBalance of
-      Some (balanceCid, balance) | transferProposal.step.delivery.amount <= balance.amount ->
-        approveProposal
-          "Approved Proposal as sender has enough balance and no banks/accounts are blacklisted"
-          cid
-          (Some balanceCid)
-          (lockBalanceCommand transferProposal balanceCid)
-      _ ->
-        rejectProposal "Rejected due to not enough balance"  cid
+  maybeBalance <- findBalance transferProposal sender
+  case maybeBalance of
+    Some (balanceCid, balance) | transferProposal.step.delivery.amount <= balance.amount ->
+        if involveBlackListParty transferProposal blacklist then
+          rejectProposal "Rejected due to blacklist" cid
+        else
+          approveProposal
+            "Approved Proposal as sender has enough balance and no banks/accounts are blacklisted"
+            cid
+            (Some balanceCid)
+            (lockBalanceCommand transferProposal balanceCid)
+    _ ->
+      rejectProposal "Rejected due to not enough balance"  cid
 
 handleProposalForReceiver : TransferProposal -> ContractId TransferProposal -> TriggerA () ()
 handleProposalForReceiver transferProposal cid = do

--- a/daml-model/daml/Trigger/AutoApprove.daml
+++ b/daml-model/daml/Trigger/AutoApprove.daml
@@ -8,13 +8,12 @@
 module Trigger.AutoApprove where
 
 import DA.Action (void, when)
-import DA.Foldable (mapA_, forA_)
+import DA.Foldable (forA_)
 import DA.List (head)
 import DA.Optional (fromSome, optionalToList)
 import Daml.Trigger
 import Model.Blacklist
 import Model.Balance
-import Model.LoanConfig
 import Workflow.TransferProposal
 import Workflow.Data
 import DA.Map qualified as Map
@@ -28,8 +27,7 @@ autoApproveTrigger = Trigger
       registeredTemplate @AutoApproveTransferProposalMarker,
       registeredTemplate @TransferProposal,
       registeredTemplate @Blacklist,
-      registeredTemplate @Balance,
-      registeredTemplate @LoanConfig
+      registeredTemplate @Balance
     ]
   , heartbeat = None
   }

--- a/daml-model/daml/Trigger/LoanManagement.daml
+++ b/daml-model/daml/Trigger/LoanManagement.daml
@@ -1,0 +1,53 @@
+--
+-- Copyright (c) 2022, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+--
+
+module Trigger.LoanManagement where
+
+import DA.Action (void)
+import DA.Foldable (forA_)
+import DA.Optional
+import Daml.Trigger
+import Model.Balance
+import Model.LoanConfig
+
+
+loanManagementTrigger : Trigger ()
+loanManagementTrigger = Trigger
+    { initialize = pure ()
+    , updateState = \_ -> pure ()
+    , rule = createLoanWhenBelowThreshold
+    , registeredTemplates = RegisteredTemplates [
+        registeredTemplate @Balance,
+        registeredTemplate @LoanConfig
+        ]
+    , heartbeat = None
+    }
+
+createLoanWhenBelowThreshold : Party -> TriggerA () ()
+createLoanWhenBelowThreshold sender = do
+    loanConfigs <- query @LoanConfig
+    balances <- fmap (\x -> snd <$> x) $ query @Balance
+    forA_ loanConfigs \(loanCid, loanConfig) -> do
+        let maybeBalance = listToOptional $ filter (correspondsTo loanConfig) balances
+        case maybeBalance of
+            Some balance | loanConfig.activeLoan < loanConfig.maxLoanThreshold -> do
+                let amount = min loanConfig.maxLoanPerTransaction (loanConfig.maxLoanThreshold - loanConfig.activeLoan)
+                createLoan balance.provider balance.iban (Some amount) loanCid
+            Some balance | loanConfig.activeLoan >= loanConfig.maxLoanThreshold -> do
+                traceA $ "Maximum loan reached for " <> loanConfig.account
+            _ -> traceA $ "No balance found for " <> loanConfig.account
+    traceA "Loan creation completed."
+
+correspondsTo : LoanConfig -> Balance -> Bool
+correspondsTo lc b = b.iban == lc.account && b.provider == lc.provider
+
+createLoan : Party -> Text -> Optional Decimal -> ContractId LoanConfig -> TriggerA () ()
+createLoan provider account loanAmount loanConfigCid = do
+    let balanceKey = BalanceKey with iban = account, provider = provider
+    let cmd = exerciseCmd loanConfigCid (CreateLoan with loanAmount = loanAmount)
+    void $ emitCommands [cmd] []
+
+traceA : (Applicative f, Show b) => b -> f ()
+traceA msg = pure $ trace msg ()

--- a/daml-model/daml/Trigger/LoanManagement.daml
+++ b/daml-model/daml/Trigger/LoanManagement.daml
@@ -17,7 +17,7 @@ loanManagementTrigger : Trigger ()
 loanManagementTrigger = Trigger
     { initialize = pure ()
     , updateState = \_ -> pure ()
-    , rule = createLoanWhenBelowThreshold
+    , rule = run
     , registeredTemplates = RegisteredTemplates [
         registeredTemplate @Balance,
         registeredTemplate @LoanConfig
@@ -25,25 +25,34 @@ loanManagementTrigger = Trigger
     , heartbeat = None
     }
 
-createLoanWhenBelowThreshold : Party -> TriggerA () ()
-createLoanWhenBelowThreshold sender = do
+run : Party -> TriggerA () ()
+run sender = do
     loanConfigs <- query @LoanConfig
     balances <- query @Balance
     let balanceMap = Map.fromList $ map ((\x -> ((x.provider, x.iban), x)) . snd) balances
     forA_ loanConfigs \(loanCid, loanConfig) -> do
         let maybeBalance = Map.lookup (loanConfig.provider, loanConfig.account) balanceMap
         case maybeBalance of
-            Some balance | loanConfig.activeLoan < loanConfig.maxLoanThreshold -> do
-                createLoan balance.provider balance.iban None loanCid
-            Some balance | loanConfig.activeLoan >= loanConfig.maxLoanThreshold -> do
-                traceA $ "Maximum loan reached for " <> loanConfig.account
+            Some balance -> do
+                createLoanWhenBelowThreshold loanCid loanConfig balance
+                createPaybackWhenAboveThreshold loanCid loanConfig balance
             _ -> traceA $ "No balance found for " <> loanConfig.account -- TODO: retire LC?
-    traceA "Loan creation completed."
 
-createLoan : Party -> Text -> Optional Decimal -> ContractId LoanConfig -> TriggerA () ()
-createLoan provider account loanAmount loanConfigCid = do
-    let cmd = exerciseCmd loanConfigCid (CreateLoan with loanAmount = loanAmount)
-    void $ emitCommands [cmd] []
+createLoanWhenBelowThreshold : ContractId LoanConfig -> LoanConfig -> Balance -> TriggerA () ()
+createLoanWhenBelowThreshold loanCid loanConfig balance
+    | balance.amount < loanConfig.balanceLoanThreshold = createLoan balance.provider balance.iban None loanCid
+    | otherwise = traceA $ "Maximum loan reached for " <> loanConfig.account
+    where createLoan provider account loanAmount loanConfigCid = do
+            let cmd = exerciseCmd loanConfigCid (CreateLoan with loanAmount = loanAmount)
+            void $ emitCommands [cmd] []
+
+createPaybackWhenAboveThreshold : ContractId LoanConfig -> LoanConfig -> Balance -> TriggerA () ()
+createPaybackWhenAboveThreshold loanCid loanConfig balance
+    | balance.amount > loanConfig.balancePaybackThreshold = createPayback balance.provider balance.iban None loanCid
+    | otherwise = traceA $ "Insufficient amount for payback " <> loanConfig.account
+    where createPayback provider account paybackAmount loanConfigCid = do
+            let cmd = exerciseCmd loanConfigCid (PaybackLoan with paybackAmount = paybackAmount)
+            void $ emitCommands [cmd] []
 
 traceA : (Applicative f, Show b) => b -> f ()
 traceA msg = pure $ trace msg ()

--- a/daml-model/daml/Trigger/LoanManagement.daml
+++ b/daml-model/daml/Trigger/LoanManagement.daml
@@ -12,7 +12,6 @@ import Daml.Trigger
 import Model.Balance
 import Model.LoanConfig
 
-
 loanManagementTrigger : Trigger ()
 loanManagementTrigger = Trigger
     { initialize = pure ()
@@ -36,7 +35,7 @@ run sender = do
             Some balance -> do
                 createLoanWhenBelowThreshold loanCid loanConfig balance
                 createPaybackWhenAboveThreshold loanCid loanConfig balance
-            _ -> traceA $ "No balance found for " <> loanConfig.account -- TODO: retire LC?
+            _ -> void $ emitCommands [exerciseCmd loanCid Archive] []
 
 createLoanWhenBelowThreshold : ContractId LoanConfig -> LoanConfig -> Balance -> TriggerA () ()
 createLoanWhenBelowThreshold loanCid loanConfig balance

--- a/daml-model/daml/Trigger/LoanManagement.daml
+++ b/daml-model/daml/Trigger/LoanManagement.daml
@@ -7,7 +7,7 @@ module Trigger.LoanManagement where
 
 import DA.Action (void)
 import DA.Foldable (forA_)
-import DA.Optional
+import DA.Map qualified as Map
 import Daml.Trigger
 import Model.Balance
 import Model.LoanConfig
@@ -28,24 +28,20 @@ loanManagementTrigger = Trigger
 createLoanWhenBelowThreshold : Party -> TriggerA () ()
 createLoanWhenBelowThreshold sender = do
     loanConfigs <- query @LoanConfig
-    balances <- fmap (\x -> snd <$> x) $ query @Balance
+    balances <- query @Balance
+    let balanceMap = Map.fromList $ map ((\x -> ((x.provider, x.iban), x)) . snd) balances
     forA_ loanConfigs \(loanCid, loanConfig) -> do
-        let maybeBalance = listToOptional $ filter (correspondsTo loanConfig) balances
+        let maybeBalance = Map.lookup (loanConfig.provider, loanConfig.account) balanceMap
         case maybeBalance of
             Some balance | loanConfig.activeLoan < loanConfig.maxLoanThreshold -> do
-                let amount = min loanConfig.maxLoanPerTransaction (loanConfig.maxLoanThreshold - loanConfig.activeLoan)
-                createLoan balance.provider balance.iban (Some amount) loanCid
+                createLoan balance.provider balance.iban None loanCid
             Some balance | loanConfig.activeLoan >= loanConfig.maxLoanThreshold -> do
                 traceA $ "Maximum loan reached for " <> loanConfig.account
-            _ -> traceA $ "No balance found for " <> loanConfig.account
+            _ -> traceA $ "No balance found for " <> loanConfig.account -- TODO: retire LC?
     traceA "Loan creation completed."
-
-correspondsTo : LoanConfig -> Balance -> Bool
-correspondsTo lc b = b.iban == lc.account && b.provider == lc.provider
 
 createLoan : Party -> Text -> Optional Decimal -> ContractId LoanConfig -> TriggerA () ()
 createLoan provider account loanAmount loanConfigCid = do
-    let balanceKey = BalanceKey with iban = account, provider = provider
     let cmd = exerciseCmd loanConfigCid (CreateLoan with loanAmount = loanAmount)
     void $ emitCommands [cmd] []
 


### PR DESCRIPTION
This (draft) PR introduces a `LoanConfig` template that provides loans to a party/account.
The `LoanManagementTrigger` then uses this template by granting loans on change of `Balance` or `LoanConfig`.

**Open tasks:**
- [x] ~~Propose/Accept pattern between `provider` and `accountHolder`~~
- [x] Implement `PaybackLoan` choice
- [x] Depend on transfers (see discussion below)
- [x] Ideally test change of balance on `CreateLoan` 

**Discussion:**
In the current draft of the LoanManagementTrigger, a loan is given for every event on `@Balance` or `@LoanConfig`. This is obviously wrong, considering that upon creation of a LoanConfig contract a loan is immediately given to the party/account. 
Instead, we aim to create a loan depending on a transfer (e.g. `TransferProposal`), such a potential (depending on the available amount) loan might prevent a transfer from failing due to insufficient balance.

> For now we'll skip propose/accept and use the account provider as the single signatory. Additionally, we define a `balanceLoanThreshold` and allow the LoanManagementTrigger to automatically provide loans to fill the account to this respective balance. Conversely, we define a `balancePaybackThreshold`, which states that amounts above this threshold are being used to payback `activeLoan` (if any). Note that `balanceLoanThreshold < balancePaybackThreshold`.