### PR TITLE
Track treasury account 

### DIFF
--- a/gui-backend/src/main/java/com/rln/gui/backend/implementation/config/SetlParty.java
+++ b/gui-backend/src/main/java/com/rln/gui/backend/implementation/config/SetlParty.java
@@ -1,11 +1,11 @@
 package com.rln.gui.backend.implementation.config;
 
-import java.util.List;
-import java.util.function.Supplier;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -18,16 +18,5 @@ public class SetlParty {
   private String damlPartyId;
   private String name;
   private List<SetlClient> clients;
-
-  public SetlClient getSetlClient(String clientName) {
-    return clients.stream()
-        .filter(client -> client.getName().equals(clientName))
-        .findFirst()
-        .orElseThrow(noSuchClient(clientName));
-  }
-
-  private Supplier<RuntimeException> noSuchClient(String clientName) {
-    return () -> new RuntimeException(
-        String.format("Setl Party %s has no such client: %s", name, clientName));
-  }
+  private List<SetlTreasuryAccount> treasuryAccounts;
 }

--- a/gui-backend/src/main/java/com/rln/gui/backend/implementation/config/SetlTreasuryAccount.java
+++ b/gui-backend/src/main/java/com/rln/gui/backend/implementation/config/SetlTreasuryAccount.java
@@ -1,0 +1,15 @@
+package com.rln.gui.backend.implementation.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class SetlTreasuryAccount {
+    private long clientId;
+    private String provider;
+    private String iban;
+    private String bearerToken;
+}

--- a/gui-backend/src/main/java/com/rln/gui/backend/implementation/config/SetlTreasuryAccount.java
+++ b/gui-backend/src/main/java/com/rln/gui/backend/implementation/config/SetlTreasuryAccount.java
@@ -1,12 +1,14 @@
 package com.rln.gui.backend.implementation.config;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
+@Builder
 public class SetlTreasuryAccount {
     private long clientId;
     private String provider;

--- a/gui-backend/src/main/java/com/rln/gui/backend/implementation/methods/AutoapproveApiImpl.java
+++ b/gui-backend/src/main/java/com/rln/gui/backend/implementation/methods/AutoapproveApiImpl.java
@@ -17,125 +17,155 @@ import com.rln.gui.backend.implementation.config.GuiBackendConfiguration;
 import com.rln.gui.backend.model.ApprovalProperties;
 import com.rln.gui.backend.model.LedgerAddressDTO;
 import com.rln.gui.backend.model.WalletAddressDTO;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 
 public class AutoapproveApiImpl {
-  private final GuiBackendConfiguration guiBackendConfiguration;
-  private final AutoApproveCache autoApproveCache;
-  private final AccountCache accountCache;
-  private final RLNClient rlnClient;
-  private final SetlPartySupplier setlPartySupplier;
-  private final RemoteOwnedAddressSupplier remoteOwnedAddressSupplier;
+    private final GuiBackendConfiguration guiBackendConfiguration;
+    private final AutoApproveCache autoApproveCache;
+    private final AccountCache accountCache;
+    private final RLNClient rlnClient;
+    private final SetlPartySupplier setlPartySupplier;
+    private final RemoteOwnedAddressSupplier remoteOwnedAddressSupplier;
 
-  public AutoapproveApiImpl(GuiBackendConfiguration guiBackendConfiguration,
-      AutoApproveCache autoApproveCache, AccountCache accountCache, RLNClient rlnClient,
-      SetlPartySupplier setlPartySupplier, RemoteOwnedAddressSupplier remoteOwnedAddressSupplier) {
-    this.guiBackendConfiguration = guiBackendConfiguration;
-    this.autoApproveCache = autoApproveCache;
-    this.accountCache = accountCache;
-    this.rlnClient = rlnClient;
-    this.setlPartySupplier = setlPartySupplier;
-    this.remoteOwnedAddressSupplier = remoteOwnedAddressSupplier;
-  }
-
-  public void updateApprovalProperties(@Valid @NotNull ApprovalProperties autoApprove) {
-    var marker = autoApproveCache.getMarker(autoApprove.getAddress());
-    var markerId = marker != null ? marker.id : null;
-    var now = Instant.now();
-    // What happens, when username is NOT the current party (in the name of which the GUI backend is running)?
-    var parameters = new AutoApproveParameters(
-        now,
-        guiBackendConfiguration.partyDamlId(),
-        autoApprove.getAddress(),
-        markerId,
-        convertApprovalMode(autoApprove),
-        autoApprove.getLimit()
-    );
-    rlnClient.createOrUpdateAutoApproveMarker(parameters);
-  }
-
-  public Object post(LedgerAddressDTO ledgerAddressDTO) {
-    return null;
-  }
-
-  public List<LedgerAddressDTO> get() {
-    var accounts = accountCache.getAccounts();
-    ArrayList<LedgerAddressDTO> result = new ArrayList<>(accounts.size());
-
-    for (var account : accounts) {
-      var autoApproval = autoApproveCache.getMarker(account.getIban());
-      var provider = setlPartySupplier.getSetlPartyByDamlParty(account.getProviderParty());
-      var client = provider.getSetlClient(account.getOwnerName());
-
-      result.add(LedgerAddressDTO.builder()
-          .isIBAN(true)
-          .address(account.getIban())
-          .id(provider.getId())
-          .bearerToken(client.getBearerToken()) // no one actually checks this
-          .clientId(client.getClientId())
-          .approvalMode(convertApproveType(autoApproval))
-          .approvalLimit(getLimit(autoApproval))
-          .build());
+    public AutoapproveApiImpl(GuiBackendConfiguration guiBackendConfiguration,
+                              AutoApproveCache autoApproveCache, AccountCache accountCache, RLNClient rlnClient,
+                              SetlPartySupplier setlPartySupplier, RemoteOwnedAddressSupplier remoteOwnedAddressSupplier) {
+        this.guiBackendConfiguration = guiBackendConfiguration;
+        this.autoApproveCache = autoApproveCache;
+        this.accountCache = accountCache;
+        this.rlnClient = rlnClient;
+        this.setlPartySupplier = setlPartySupplier;
+        this.remoteOwnedAddressSupplier = remoteOwnedAddressSupplier;
     }
 
-    return result;
-  }
-
-  public List<WalletAddressDTO> getWalletAddresses() {
-    var accounts = accountCache.getAccounts();
-    var remoteOwnedAddresses = remoteOwnedAddressSupplier.getRemoteOwnedAddresses();
-    ArrayList<WalletAddressDTO> result = new ArrayList<>(remoteOwnedAddresses.size() + accounts.size());
-
-    result.addAll(remoteOwnedAddresses);
-    for (var account : accounts) {
-      var setlPartyId = setlPartySupplier.getSetlPartyIdByDamlParty(account.getProviderParty());
-      result.add(WalletAddressDTO.builder()
-          .address(account.getIban())
-          .partyId(setlPartyId)
-          .bearerToken(account.getBearerToken())
-          .walletId(GuiBackendApiImplementation.ONLY_SUPPORTED_WALLET_ID)
-          .build());
+    public void updateApprovalProperties(@Valid @NotNull ApprovalProperties autoApprove) {
+        var marker = autoApproveCache.getMarker(autoApprove.getAddress());
+        var markerId = marker != null ? marker.id : null;
+        var now = Instant.now();
+        // What happens, when username is NOT the current party (in the name of which the GUI backend is running)?
+        var parameters = new AutoApproveParameters(
+                now,
+                guiBackendConfiguration.partyDamlId(),
+                autoApprove.getAddress(),
+                markerId,
+                convertApprovalMode(autoApprove),
+                autoApprove.getLimit()
+        );
+        rlnClient.createOrUpdateAutoApproveMarker(parameters);
     }
 
-    return result;
-  }
+    public Object post(LedgerAddressDTO ledgerAddressDTO) {
+        return null;
+    }
 
-  private String convertApproveType(Contract autoApproval) {
-    if (autoApproval == null) {
-      return "MANUAL";
-    }
-    var autoApproveType = autoApproval.data.autoApproveType;
-    if (autoApproveType instanceof FullAuto) {
-      return "AUTO";
-    } else if (autoApproveType instanceof LimitedMaxAmount) {
-      return "LIMIT";
-    } else {
-      throw new RuntimeException("Unknown approve mode/type: " + autoApproveType);
-    }
-  }
+    public List<LedgerAddressDTO> get() {
+        var accounts = accountCache.getAccounts();
+        ArrayList<LedgerAddressDTO> result = new ArrayList<>(accounts.size());
 
-  private Double getLimit(Contract autoApprove) {
-    if (autoApprove != null) {
-      var autoApproveType = autoApprove.data.autoApproveType;
-      if (autoApproveType instanceof LimitedMaxAmount) {
-        return ((LimitedMaxAmount) autoApproveType).bigDecimalValue.doubleValue();
-      }
-    }
-    return null;
-  }
+        for (var account : accounts) {
+            var autoApproval = autoApproveCache.getMarker(account.getIban());
+            var provider = setlPartySupplier.getSetlPartyByDamlParty(account.getProviderParty());
 
-  private ApprovalMode convertApprovalMode(ApprovalProperties autoApprove) {
-    switch (autoApprove.getApprovalMode()) {
-      case AUTO:
-        return ApprovalMode.AUTO;
-      case LIMIT:
-        return ApprovalMode.LIMIT;
-      default:
-        return ApprovalMode.MANUAL;
+            var treasuryAccount = setlPartySupplier.getTreasuryAccountByProviderPartyIdAndIBAN(
+                    account.getProviderParty(),
+                    account.getIban()
+            );
+            var clientAccount = setlPartySupplier.getClientByProviderPartyIdAndIban(
+                    account.getProviderParty(),
+                    account.getIban()
+            );
+
+            clientAccount.map(client ->
+                    result.add(LedgerAddressDTO.builder()
+                            .isIBAN(true)
+                            .address(account.getIban())
+                            .id(provider.getId())
+                            .bearerToken(client.getBearerToken()) // no one actually checks this
+                            .clientId(client.getClientId())
+                            .approvalMode(convertApproveType(autoApproval))
+                            .approvalLimit(getLimit(autoApproval))
+                            .build())
+            );
+
+            treasuryAccount.map(treasury ->
+                    result.add(LedgerAddressDTO.builder()
+                            .isIBAN(true)
+                            .address(account.getIban())
+                            .id(provider.getId())
+                            .bearerToken(treasury.getBearerToken()) // no one actually checks this
+                            .clientId(treasury.getClientId())
+                            .approvalMode(convertApproveType(autoApproval))
+                            .approvalLimit(getLimit(autoApproval))
+                            .build())
+            );
+
+            if (treasuryAccount.isEmpty() && clientAccount.isEmpty())
+                throw new IllegalStateException(String.format(
+                        "Setl Party %s has no client or treasury accounts with IBAN: %s",
+                        account.getOwnerName(),
+                        account.getIban()
+                ));
+        }
+
+        return result;
     }
-  }
+
+    public List<WalletAddressDTO> getWalletAddresses() {
+        var accounts = accountCache.getAccounts();
+        var remoteOwnedAddresses = remoteOwnedAddressSupplier.getRemoteOwnedAddresses();
+        ArrayList<WalletAddressDTO> result = new ArrayList<>(remoteOwnedAddresses.size() + accounts.size());
+
+        result.addAll(remoteOwnedAddresses);
+        for (var account : accounts) {
+            var setlPartyId = setlPartySupplier.getSetlPartyIdByDamlParty(account.getProviderParty());
+            result.add(WalletAddressDTO.builder()
+                    .address(account.getIban())
+                    .partyId(setlPartyId)
+                    .bearerToken(account.getBearerToken())
+                    .walletId(GuiBackendApiImplementation.ONLY_SUPPORTED_WALLET_ID)
+                    .build());
+        }
+
+        return result;
+    }
+
+    private String convertApproveType(Contract autoApproval) {
+        if (autoApproval == null) {
+            return "MANUAL";
+        }
+        var autoApproveType = autoApproval.data.autoApproveType;
+        if (autoApproveType instanceof FullAuto) {
+            return "AUTO";
+        } else if (autoApproveType instanceof LimitedMaxAmount) {
+            return "LIMIT";
+        } else {
+            throw new RuntimeException("Unknown approve mode/type: " + autoApproveType);
+        }
+    }
+
+    private Double getLimit(Contract autoApprove) {
+        if (autoApprove != null) {
+            var autoApproveType = autoApprove.data.autoApproveType;
+            if (autoApproveType instanceof LimitedMaxAmount) {
+                return ((LimitedMaxAmount) autoApproveType).bigDecimalValue.doubleValue();
+            }
+        }
+        return null;
+    }
+
+    private ApprovalMode convertApprovalMode(ApprovalProperties autoApprove) {
+        switch (autoApprove.getApprovalMode()) {
+            case AUTO:
+                return ApprovalMode.AUTO;
+            case LIMIT:
+                return ApprovalMode.LIMIT;
+            default:
+                return ApprovalMode.MANUAL;
+        }
+    }
 }

--- a/gui-backend/src/main/java/com/rln/gui/backend/implementation/methods/SetlPartySupplier.java
+++ b/gui-backend/src/main/java/com/rln/gui/backend/implementation/methods/SetlPartySupplier.java
@@ -2,7 +2,10 @@ package com.rln.gui.backend.implementation.methods;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rln.gui.backend.implementation.config.SetlClient;
 import com.rln.gui.backend.implementation.config.SetlParty;
+import com.rln.gui.backend.implementation.config.SetlTreasuryAccount;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -13,45 +16,64 @@ import java.util.stream.Collectors;
 
 public class SetlPartySupplier {
 
-  private final Path setlPartiesConfig;
-  private final Map<Long, SetlParty> parties;
-  private final Map<String, SetlParty> damlPartyToSetlParty;
+    private final Path setlPartiesConfig;
+    private final Map<Long, SetlParty> parties;
+    private final Map<String, SetlParty> damlPartyToSetlParty;
 
-  public SetlPartySupplier(Path setlPartiesConfig) {
-    this.setlPartiesConfig = setlPartiesConfig;
-    this.parties = readSetlPartiesFromConfig();
-    this.damlPartyToSetlParty = getParties().stream()
-        .collect(Collectors.toMap(SetlParty::getDamlPartyId, i -> i));
-  }
-
-  public Collection<SetlParty> getParties() {
-    return parties.values();
-  }
-
-  public SetlParty getSetlPartyBySetlPartyId(Long setlPartyId) {
-    return parties.get(setlPartyId);
-  }
-
-  public SetlParty getSetlPartyByDamlParty(String damlPartyId) {
-    return damlPartyToSetlParty.get(damlPartyId);
-  }
-
-  public Long getSetlPartyIdByDamlParty(String damlPartyId) {
-    return Optional.ofNullable(damlPartyToSetlParty.get(damlPartyId))
-        .map(SetlParty::getId)
-        .orElse(null);
-  }
-
-  private Map<Long, SetlParty> readSetlPartiesFromConfig() {
-    try {
-      return new ObjectMapper()
-          .readValue(
-              setlPartiesConfig.toFile(),
-              new TypeReference<List<SetlParty>>() {})
-          .stream()
-          .collect(Collectors.toMap(SetlParty::getId, s -> s));
-    } catch (IOException e) {
-      throw new InternalServerError(e);
+    public SetlPartySupplier(Path setlPartiesConfig) {
+        this.setlPartiesConfig = setlPartiesConfig;
+        this.parties = readSetlPartiesFromConfig();
+        this.damlPartyToSetlParty = getParties().stream()
+                .collect(Collectors.toMap(SetlParty::getDamlPartyId, i -> i));
     }
-  }
+
+    public Collection<SetlParty> getParties() {
+        return parties.values();
+    }
+
+    public SetlParty getSetlPartyBySetlPartyId(Long setlPartyId) {
+        return parties.get(setlPartyId);
+    }
+
+    public SetlParty getSetlPartyByDamlParty(String damlPartyId) {
+        return damlPartyToSetlParty.get(damlPartyId);
+    }
+
+    public Long getSetlPartyIdByDamlParty(String damlPartyId) {
+        return Optional.ofNullable(damlPartyToSetlParty.get(damlPartyId))
+                .map(SetlParty::getId)
+                .orElse(null);
+    }
+
+    public Optional<SetlTreasuryAccount> getTreasuryAccountByProviderPartyIdAndIBAN(String providerPartyId, String iban) {
+        var providerName = getSetlPartyByDamlParty(providerPartyId).getName();
+        return getParties().stream()
+                .map(SetlParty::getTreasuryAccounts)
+                .flatMap(List::stream)
+                .filter(treasury -> treasury.getProvider().equals(providerName))
+                .filter(treasury -> treasury.getIban().equals(iban))
+                .findFirst();
+    }
+
+    public Optional<SetlClient> getClientByProviderPartyIdAndIban(String providerPartyId, String iban) {
+        var provider = getSetlPartyByDamlParty(providerPartyId);
+        return provider.getClients().stream()
+                .filter(client -> client.getIban().equals(iban))
+                .findFirst();
+    }
+
+
+    private Map<Long, SetlParty> readSetlPartiesFromConfig() {
+        try {
+            return new ObjectMapper()
+                    .readValue(
+                            setlPartiesConfig.toFile(),
+                            new TypeReference<List<SetlParty>>() {
+                            })
+                    .stream()
+                    .collect(Collectors.toMap(SetlParty::getId, s -> s));
+        } catch (IOException e) {
+            throw new InternalServerError(e);
+        }
+    }
 }

--- a/gui-backend/src/test/java/com/rln/gui/backend/implementation/methods/PartyApiImplTest.java
+++ b/gui-backend/src/test/java/com/rln/gui/backend/implementation/methods/PartyApiImplTest.java
@@ -10,8 +10,10 @@ import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
+
 import java.util.List;
 import javax.inject.Inject;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -21,58 +23,69 @@ import org.mockito.BDDMockito;
 @QuarkusTest
 class PartyApiImplTest extends LedgerBaseTest {
 
-  @InjectMock
-  SetlPartySupplier setlPartySupplier;
+    @InjectMock
+    SetlPartySupplier setlPartySupplier;
 
-  @Inject
-  PartyApiImpl partyApi;
+    @Inject
+    PartyApiImpl partyApi;
 
-  @Test
-  void getMyParty() {
-    PartyDTO expected = new PartyDTO(LedgerBaseTest.BASEURL, List.of(LedgerBaseTest.BANK_BIC),
-        LedgerBaseTest.PARTY_ID, LedgerBaseTest.PARTY_NAME);
+    @Test
+    void getMyParty() {
+        PartyDTO expected = new PartyDTO(LedgerBaseTest.BASEURL, List.of(LedgerBaseTest.BANK_BIC),
+                LedgerBaseTest.PARTY_ID, LedgerBaseTest.PARTY_NAME);
 
-    PartyDTO result = RestAssured
-        .get("/api/parties/me")
-        .then()
-        .statusCode(200)
-        .extract().body().as(new TypeRef<>() {
-        });
+        PartyDTO result = RestAssured
+                .get("/api/parties/me")
+                .then()
+                .statusCode(200)
+                .extract().body().as(new TypeRef<>() {
+                });
 
-    MatcherAssert.assertThat(result, Matchers.is(expected));
-  }
+        MatcherAssert.assertThat(result, Matchers.is(expected));
+    }
 
-  @Test
-  void getParties() {
-    BDDMockito.given(setlPartySupplier.getParties()).willReturn(List.of(
-        new SetlParty(BASEURL, PARTY_ID, getCurrentBankPartyId().getValue(), PARTY_NAME,
-            List.of())));
+    @Test
+    void getParties() {
+        BDDMockito.given(setlPartySupplier.getParties()).willReturn(List.of(
+                new SetlParty(BASEURL,
+                        PARTY_ID,
+                        getCurrentBankPartyId().getValue(),
+                        PARTY_NAME,
+                        List.of(),
+                        List.of())
+        ));
 
-    List<PartyDTO> result = RestAssured
-        .get("/api/parties")
-        .then()
-        .statusCode(200)
-        .extract().body().as(new TypeRef<>() {
-        });
+        List<PartyDTO> result = RestAssured
+                .get("/api/parties")
+                .then()
+                .statusCode(200)
+                .extract().body().as(new TypeRef<>() {
+                });
 
-    MatcherAssert.assertThat(result, Matchers.not(Matchers.empty()));
-  }
+        MatcherAssert.assertThat(result, Matchers.not(Matchers.empty()));
+    }
 
-  @Test
-  void getClients() {
-    List<SetlClient> clients = List.of(new SetlClient(CLIENT_ID, CLIENT_NAME, SENDER_IBAN, "token-" + SENDER_IBAN));
-    ClientDTO expected = new ClientDTO(CLIENT_ID, CLIENT_NAME);
-    BDDMockito.given(setlPartySupplier.getSetlPartyByDamlParty(getCurrentBankPartyId().getValue()))
-        .willReturn(new SetlParty(BASEURL, PARTY_ID, getCurrentBankPartyId().getValue(), PARTY_NAME,
-            clients));
+    @Test
+    void getClients() {
+        List<SetlClient> clients = List.of(new SetlClient(CLIENT_ID, CLIENT_NAME, SENDER_IBAN, "token-" + SENDER_IBAN));
+        ClientDTO expected = new ClientDTO(CLIENT_ID, CLIENT_NAME);
+        BDDMockito.given(setlPartySupplier.getSetlPartyByDamlParty(getCurrentBankPartyId().getValue()))
+                .willReturn(new SetlParty(
+                        BASEURL,
+                        PARTY_ID,
+                        getCurrentBankPartyId().getValue(),
+                        PARTY_NAME,
+                        clients,
+                        List.of())
+                );
 
-    List<ClientDTO> result = RestAssured
-        .get("/api/ledger/clients")
-        .then()
-        .statusCode(200)
-        .extract().body().as(new TypeRef<>() {
-        });
+        List<ClientDTO> result = RestAssured
+                .get("/api/ledger/clients")
+                .then()
+                .statusCode(200)
+                .extract().body().as(new TypeRef<>() {
+                });
 
-    MatcherAssert.assertThat(result, Matchers.hasItem(expected));
-  }
+        MatcherAssert.assertThat(result, Matchers.hasItem(expected));
+    }
 }

--- a/onboarding/daml/Onboarding.daml
+++ b/onboarding/daml/Onboarding.daml
@@ -10,7 +10,7 @@ import Model.BankBIC
 import Model.Balance
 import DA.Set qualified as Set
 import DA.Foldable (mapA_, forA_)
-import DA.Optional (mapOptional, fromSomeNote, whenSome)
+import DA.Optional (mapOptional, fromSomeNote, whenSome, fromOptional)
 import qualified DA.TextMap as TextMap
 import DA.TextMap (TextMap)
 import DA.Action (foldlA, void)
@@ -29,9 +29,11 @@ data PartyInfo = PartyInfo with
   clients : [ClientInfo]
 
 data Account = Account with
-  provider : Text
-  iban : Iban
-  bearerToken : Text
+    clientId : Int
+    provider : Text
+    iban : Iban
+    bearerToken : Text
+  deriving (Eq, Show)
 
 type Iban = Text
 
@@ -54,6 +56,7 @@ data BankEntry = BankEntry with
     baseUrl : Text
     damlPartyId : Party
     name : Text
+    treasuryAccounts : [Account]
     clients : [ClientInfo]
   deriving (Eq, Show)
 
@@ -95,6 +98,7 @@ extractConfig partyInfo = do
               baseUrl = info.baseUrl
               damlPartyId = party
               name = info.name
+              treasuryAccounts = fromOptional [] info.accounts
               clients = info.clients
           )
           <$> TextMap.lookup info.bic bics)
@@ -166,6 +170,7 @@ setupBank parties partyInfo = do
       baseUrl = partyInfo.baseUrl
       damlPartyId = party
       name = partyInfo.name
+      treasuryAccounts = fromOptional [] partyInfo.accounts
       clients = partyInfo.clients
 
 -- Helper


### PR DESCRIPTION
Accounts on the ledger represent either
- client account 
- or a treasury account

When generating the configuration during Onboarding, we now additionally expose `treasuryAccounts`, next to `clients`.
Hence, when searching for a SetlAccount given the ledger information (represented as `AccountInfo`) we're required to lookup if this corresponds to a `SetlTreasuryAccount` or a `SetlClient` and whichever yields a result will be used.
