### PR TITLE
Include treasury accounts in clients api endpoint

### DIFF
--- a/gui-backend/src/main/java/com/rln/gui/backend/implementation/methods/PartyApiImpl.java
+++ b/gui-backend/src/main/java/com/rln/gui/backend/implementation/methods/PartyApiImpl.java
@@ -11,6 +11,7 @@ import com.rln.gui.backend.model.ClientDTO;
 import com.rln.gui.backend.model.PartyDTO;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class PartyApiImpl {
 
@@ -49,14 +50,23 @@ public class PartyApiImpl {
   }
 
   public List<ClientDTO> getClients() {
-    return setlPartySupplier
+    var clients = setlPartySupplier
         .getSetlPartyByDamlParty(guiBackendConfiguration.partyDamlId())
         .getClients().stream()
         .map(setlClient ->
             ClientDTO.builder()
              .id(setlClient.getClientId())
              .name(setlClient.getName())
-            .build())
-        .collect(Collectors.toList());
+            .build());
+
+    var treasuries = setlPartySupplier
+            .getTreasuryAccountsByProviderParty(guiBackendConfiguration.partyDamlId())
+            .stream().map(treasuryAccount ->
+                    ClientDTO.builder()
+                            .id(treasuryAccount.getClientId())
+                            .name(treasuryAccount.getIban())
+                            .build());
+
+    return Stream.concat(clients, treasuries).collect(Collectors.toList());
   }
 }

--- a/gui-backend/src/main/java/com/rln/gui/backend/implementation/methods/SetlPartySupplier.java
+++ b/gui-backend/src/main/java/com/rln/gui/backend/implementation/methods/SetlPartySupplier.java
@@ -45,12 +45,18 @@ public class SetlPartySupplier {
                 .orElse(null);
     }
 
-    public Optional<SetlTreasuryAccount> getTreasuryAccountByProviderPartyIdAndIBAN(String providerPartyId, String iban) {
+    public List<SetlTreasuryAccount> getTreasuryAccountsByProviderParty(String providerPartyId) {
         var providerName = getSetlPartyByDamlParty(providerPartyId).getName();
         return getParties().stream()
                 .map(SetlParty::getTreasuryAccounts)
                 .flatMap(List::stream)
                 .filter(treasury -> treasury.getProvider().equals(providerName))
+                .collect(Collectors.toList());
+    }
+
+    public Optional<SetlTreasuryAccount> getTreasuryAccountByProviderPartyIdAndIBAN(String providerPartyId, String iban) {
+        return getTreasuryAccountsByProviderParty(providerPartyId)
+                .stream()
                 .filter(treasury -> treasury.getIban().equals(iban))
                 .findFirst();
     }


### PR DESCRIPTION
This includes the treasury accounts in `/ledger/clients` where the current bank is acting as the provider of such accounts.

Given our default config file the result for `Daml Demo 1` is:
```
[
    {"id":1,"name":"Client 1"},
    {"id":2,"name":"Client 2"},
    {"id":0,"name":"US15DEM320032683377878"},
    {"id":3,"name":"US10DEM110016547488963"}
]
```